### PR TITLE
Add indicators to UI for changes in the z-axis depth

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -160,21 +160,14 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             Line(points = (self.offsetX + self.xPosition , self.offsetY + self.yPosition , self.offsetX +  xTarget, self.offsetY  + yTarget), width = 1, group = 'gcode')
         
         if not zTarget == self.zPosition:
-            print "z change in line:"
-            print gCodeLine
-            print zTarget
-            print self.zPosition
-            print zTarget - self.zPosition
             if zTarget - self.zPosition > 0:
-                print "going up"
                 with self.scatterObject.canvas:
                     Color(0, 1, 0)
-                    Line(circle=(self.offsetX + self.xPosition , self.offsetY + self.yPosition, 3))
+                    Line(circle=(self.offsetX + self.xPosition , self.offsetY + self.yPosition, 2), width = 2)
             else:
-                print "going down"
                 with self.scatterObject.canvas:
                     Color(1, 0, 0)
-                    Line(circle=(self.offsetX + self.xPosition , self.offsetY + self.yPosition, 5))
+                    Line(circle=(self.offsetX + self.xPosition , self.offsetY + self.yPosition, 4), width = 2)
         
         self.xPosition = xTarget
         self.yPosition = yTarget

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -159,7 +159,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             Color(1, 1, 1)
             Line(points = (self.offsetX + self.xPosition , self.offsetY + self.yPosition , self.offsetX +  xTarget, self.offsetY  + yTarget), width = 1, group = 'gcode')
         
-        if not zTarget == self.zPosition:
+        if not zTarget == self.zPosition: #If the zposition has changed, add indicators
             if zTarget - self.zPosition > 0:
                 with self.scatterObject.canvas:
                     Color(0, 1, 0)

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -36,6 +36,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
     
     xPosition = 0
     yPosition = 0
+    zPosition = 0
     
     def initialzie(self):
         with self.scatterObject.canvas:
@@ -140,6 +141,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         
         xTarget = self.xPosition
         yTarget = self.yPosition
+        zTarget = self.zPosition
         
         x = re.search("X(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
         if x:
@@ -149,12 +151,34 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         if y:
             yTarget = float(y.groups()[0])*self.canvasScaleFactor
         
+        z = re.search("Z(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
+        if z:
+            zTarget = float(z.groups()[0])*self.canvasScaleFactor
+        
         with self.scatterObject.canvas:
             Color(1, 1, 1)
             Line(points = (self.offsetX + self.xPosition , self.offsetY + self.yPosition , self.offsetX +  xTarget, self.offsetY  + yTarget), width = 1, group = 'gcode')
         
+        if not zTarget == self.zPosition:
+            print "z change in line:"
+            print gCodeLine
+            print zTarget
+            print self.zPosition
+            print zTarget - self.zPosition
+            if zTarget - self.zPosition > 0:
+                print "going up"
+                with self.scatterObject.canvas:
+                    Color(0, 1, 0)
+                    Line(circle=(self.offsetX + self.xPosition , self.offsetY + self.yPosition, 3))
+            else:
+                print "going down"
+                with self.scatterObject.canvas:
+                    Color(1, 0, 0)
+                    Line(circle=(self.offsetX + self.xPosition , self.offsetY + self.yPosition, 5))
+        
         self.xPosition = xTarget
         self.yPosition = yTarget
+        self.zPosition = zTarget
     
     def drawG2(self,gCodeLine):
         

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -66,7 +66,7 @@
                 text: '>^'
                 on_press: root.upRight()
             Button:
-                text: 'UP'
+                text: 'Z-OUT'
                 on_press: root.zUp()
             Button:
                 text: '<'
@@ -78,7 +78,7 @@
                 text: '>'
                 on_press: root.right()
             Button:
-                text: 'DOWN'
+                text: 'Z-IN'
                 on_press: root.zDown()
             Button:
                 text: '<\/'


### PR DESCRIPTION
Motions into the board are displayed using a red circle, and motions out of the board are indicated using a green circle. The red is larger so that at points where the bit moves into and back out of the wood, both are indicated