### PR TITLE
Avoid crash at end of gcode file

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -88,7 +88,10 @@ class FrontPage(Screen, MakesmithInitFuncs):
     
     def moveGcodeIndex(self, dist):
         self.data.gcodeIndex = self.data.gcodeIndex + dist
-        gCodeLine = self.data.gcode[self.data.gcodeIndex]
+        try:
+            gCodeLine = self.data.gcode[self.data.gcodeIndex]
+        except IndexError:
+            gCodeLine = 'end of file'
         print gCodeLine
         
         xTarget = 0

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -100,10 +100,26 @@ class FrontPage(Screen, MakesmithInitFuncs):
         x = re.search("X(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
         if x:
             xTarget = float(x.groups()[0])
+        else:
+            if self.data.units == "INCHES":
+                xTarget = self.gcodecanvas.targetIndicator.pos[0] / 25.4
+            else:
+                xTarget = self.gcodecanvas.targetIndicator.pos[0]              
         
         y = re.search("Y(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
         if y:
             yTarget = float(y.groups()[0])
+        else:
+            if self.data.units == "INCHES":
+                yTarget = self.gcodecanvas.targetIndicator.pos[1] / 25.4
+            else:
+                yTarget = self.gcodecanvas.targetIndicator.pos[1] 
+
+        z = re.search("Z", gCodeLine)
+        if z:
+            self.gcodecanvas.targetIndicator.color = (1,1,1)
+        else:
+            self.gcodecanvas.targetIndicator.color = (1,0,0)
         
         self.gcodecanvas.targetIndicator.setPos(xTarget,yTarget,self.data.units)
     


### PR DESCRIPTION
Using step controls should avoid stepping past the end of the gcode
file.