### PR TITLE
Typo in gcodeCanvas.py

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -315,7 +315,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                 
             if opstring[0:3] == 'G21':
                 self.canvasScaleFactor = self.MILLIMETERS
-                Self.data.units = "MM"
+                self.data.units = "MM"
                 
             if opstring[0:3] == 'G90':
                 self.absoluteFlag = 1


### PR DESCRIPTION
Fixed a typo which caused the toolpath to not be displayed in groundcontrol when the G21 command was encountered while parsing a gcode file.