### PR TITLE
Workaround for line limitation in ScrollableTextPopup

### DIFF
--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -96,8 +96,12 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         if len(self.data.gcode) is 0:
             popupText =  "No gcode to display"
         else:
-            for gcodeLine in self.data.gcode:
-                popupText = popupText + gcodeLine + "\n"
+            for lineNum, gcodeLine in enumerate(self.data.gcode):
+                if lineNum<447:
+                    popupText = popupText + gcodeLine + "\n"
+                else:
+                    popupText = popupText + "...\n...\n...\n"
+                    break
                 
         content = ScrollableTextPopup(cancel = self.dismiss_popup, text = popupText)
         self._popup = Popup(title="Gcode", content=content,


### PR DESCRIPTION
I found that long Gcode files weren't showing up in the Actions>View Gcode modal window. It scrolls but is empty (first image). Through a process of elimination I found the maximum is ~450 lines though it appears to vary based on line length (so it's really probably a size issue rather than a number of lines issue). I'm not familiar enough with kivy to determine exactly why this is the case so I'm proposing a workaround where the Gcode is just truncated to 450 lines with some ellipses at the end (second image).

![empty](https://cloud.githubusercontent.com/assets/16262066/23298952/8a3bd1aa-fae4-11e6-969d-2d9eeff1b148.png)

![truncated](https://cloud.githubusercontent.com/assets/16262066/23298957/8e68a672-fae4-11e6-82e4-4cc8d07aff6b.png)

