### PR TITLE
Master

### DIFF
--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -31,6 +31,8 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         
         '''
         content = LoadDialog(load=self.load, cancel=self.dismiss_popup)
+        if content.path is "": 
+            content.path = path.expanduser('~')
         content.path = path.dirname(self.data.gcodeFile)
         self._popup = Popup(title="Load file", content=content,
                             size_hint=(0.9, 0.9))


### PR DESCRIPTION
When running for the first time, or without a gcode file selected, or
when the gcode file cannot be found, the 'openFile’ dialog starts
within the file structure of groundcontrol itself. This can be
confusing.
Instead, use the user’s home directory as the starting point. A
two-line change to viewMenu would set the path to path.expanduser('~')
if the gcode file is not found.