### PR TITLE
Open gcode list view

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -38,7 +38,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
     yPosition = 0
     zPosition = 0
     
-    def initialzie(self):
+    def initialize(self):
         with self.scatterObject.canvas:
             Color(1, 1, 1)
             

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -221,7 +221,8 @@
             on_press: root.show_gcode()
         Button:
             text: 'Reset Origin'
-            disabled: True
+            disabled: False
+            on_press: root.show_gcode()
                 
 <RunMenu>:
     GridLayout:
@@ -474,13 +475,24 @@
         size: root.size
         pos: root.pos
         orientation: "vertical"
-        FileChooserIconView:
+        FileChooser:
             id: filechooser
             path: root.path
+            FileChooserIconLayout
+            FileChooserListLayout
 
         BoxLayout:
             size_hint_y: None
             height: dp(30)
+            Button:
+                text: 'Icon View'
+                on_press: filechooser.view_mode = 'icon'
+                size_hint_x: 0.3
+            Button:
+                text: 'List View'
+                on_press: filechooser.view_mode = 'list'
+                size: root.width/8,root.height
+                size_hint_x: 0.3
             Button:
                 text: "Load"
                 on_release: root.load(filechooser.path, filechooser.selection)

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -221,8 +221,7 @@
             on_press: root.show_gcode()
         Button:
             text: 'Reset Origin'
-            disabled: False
-            on_press: root.show_gcode()
+            disabled: True
                 
 <RunMenu>:
     GridLayout:

--- a/main.py
+++ b/main.py
@@ -96,7 +96,7 @@ class GroundControlApp(App):
         
         self.frontpage.setUpData(self.data)
         self.nonVisibleWidgets.setUpData(self.data)
-        self.frontpage.gcodecanvas.initialzie()
+        self.frontpage.gcodecanvas.initialize()
         
         
         '''


### PR DESCRIPTION
I added buttons to the open file popup to enable switching between icon and list view. The reason being that I was having trouble differentiating between files with long names in the icon view. I assume the icon view was initially selected intentionally thus the buttons to preserve that while also allowing the list view. In the kivy documentation ([link](https://kivy.org/docs/api-kivy.uix.filechooser.html?highlight=filechooserlistview#kivy.uix.filechooser.FileChooserListView)) the file names in list view are left justified but for some reason mine show up centered. I think left justified looks much better but couldn't figure out how to easily change it.