### PR TITLE
Repurposed disabled "Reset Origin" button in view menu to reset the view.

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -220,8 +220,9 @@
             disabled: False
             on_press: root.show_gcode()
         Button:
-            text: 'Reset Origin'
-            disabled: True
+            text: 'Reset View'
+            disabled: False
+            on_press: app.frontpage.gcodecanvas.centerScatter()
                 
 <RunMenu>:
     GridLayout:


### PR DESCRIPTION
I had a few instances where the zoom/pan of the gcode canvas got out of whack and I couldn't find the workpiece. I had to then close and reopen ground control to get back which was annoying. The "Reset View" button now uses the centerScatter function of GcodeCanvas.py to recenter and zoom the gcode canvas. Let me know if you would like this implemented differently but I think the functionality is useful.