### PR TITLE
Pr 92 - rev 2

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -114,41 +114,18 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.shiftY = 0
     
     def moveGcodeIndex(self, dist):
-        self.data.gcodeIndex = self.data.gcodeIndex + dist
-        try:
-            gCodeLine = self.data.gcode[self.data.gcodeIndex]
-        except IndexError:
-            gCodeLine = 'end of file'
-        print gCodeLine
-        
-        xTarget = 0
-        yTarget = 0
-        
-        x = re.search("X(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
-        if x:
-            xTarget = float(x.groups()[0])
-        else:
-            if self.data.units == "INCHES":
-                xTarget = self.gcodecanvas.targetIndicator.pos[0] / 25.4
-            else:
-                xTarget = self.gcodecanvas.targetIndicator.pos[0]              
-        
-        y = re.search("Y(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
-        if y:
-            yTarget = float(y.groups()[0])
-        else:
-            if self.data.units == "INCHES":
-                yTarget = self.gcodecanvas.targetIndicator.pos[1] / 25.4
-            else:
-                yTarget = self.gcodecanvas.targetIndicator.pos[1] 
+        maxIndex = len(self.data.gcode)-1
+        targetIndex = self.data.gcodeIndex + dist
 
-        z = re.search("Z", gCodeLine)
-        if z:
-            self.gcodecanvas.targetIndicator.color = (1,1,1)
+        if targetIndex < 0:
+            self.data.gcodeIndex = 0
+        elif targetIndex > maxIndex:
+            self.data.gcodeIndex = maxIndex
         else:
-            self.gcodecanvas.targetIndicator.color = (1,0,0)
-        
-        self.gcodecanvas.targetIndicator.setPos(xTarget,yTarget,self.data.units)
+            self.data.gcodeIndex = targetIndex
+
+        gCodeLine = self.data.gcode[self.data.gcodeIndex]
+        print gCodeLine
     
     def pause(self):
         self.data.uploadFlag = 0

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -105,7 +105,7 @@ class FrontPage(Screen, MakesmithInitFuncs):
     
     def onIndexMove(self, callback, newIndex):
         self.gcodeLineNumber = str(newIndex)
-        self.percentComplete = '%.1f' %(100* (float(newIndex) / len(self.data.gcode))) + "%"
+        self.percentComplete = '%.1f' %(100* (float(newIndex) / (len(self.data.gcode)-1))) + "%"
     
     def onGcodeFileChange(self, callback, newGcode):
     

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -125,7 +125,29 @@ class FrontPage(Screen, MakesmithInitFuncs):
             self.data.gcodeIndex = targetIndex
 
         gCodeLine = self.data.gcode[self.data.gcodeIndex]
-        print gCodeLine
+        
+        xTarget = 0
+        yTarget = 0
+        
+        x = re.search("X(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
+        if x:
+            xTarget = float(x.groups()[0])
+        else:
+            if self.data.units == "INCHES":
+                xTarget = self.gcodecanvas.positionIndicator.pos[0] / 25.4
+            else:
+                xTarget = self.gcodecanvas.positionIndicator.pos[0]              
+        
+        y = re.search("Y(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
+        if y:
+            yTarget = float(y.groups()[0])
+        else:
+            if self.data.units == "INCHES":
+                yTarget = self.gcodecanvas.positionIndicator.pos[1] / 25.4
+            else:
+                yTarget = self.gcodecanvas.positionIndicator.pos[1] 
+        
+        self.gcodecanvas.positionIndicator.setPos(xTarget,yTarget,self.data.units, 0)
     
     def pause(self):
         self.data.uploadFlag = 0

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -112,6 +112,9 @@ class FrontPage(Screen, MakesmithInitFuncs):
         #reset the shift values to 0 because the new gcode is not loaded with a shift applied
         self.shiftX = 0
         self.shiftY = 0
+        
+        #reset the gcode index to the beginning
+        self.moveGcodeIndex(0);
     
     def moveGcodeIndex(self, dist):
         maxIndex = len(self.data.gcode)-1

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -113,8 +113,9 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.shiftX = 0
         self.shiftY = 0
         
-        #reset the gcode index to the beginning
-        self.moveGcodeIndex(0);
+        #reset the gcode index to the beginning and update the display
+        self.data.gcodeIndex = 0
+        self.moveGcodeIndex(0)
     
     def moveGcodeIndex(self, dist):
         maxIndex = len(self.data.gcode)-1


### PR DESCRIPTION
Building on @johnbenweber work in #92 . Added back in the position indicator shown while fast forwarding and fixing an index error so that the % complete ends at 100%.

@blurfl Do you think it's clear enough that the user is at the begning or end of the file? We could disable (turn grey) the buttons to FF or rewind if the user is at the begining or end of the file to make it more clear.