### PR TITLE
Workaround for gcode comments being interpreted as coordinates.

### DIFF
--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -67,7 +67,9 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         try:
             filterfile = open(filename, 'r')
             rawfilters = filterfile.read()
-            filtersparsed = re.split(r'\s(?=G)|\n|\s(?=g)|\s(?=M)', rawfilters) #splits the gcode into elements to be added to the list
+            filtersparsed = re.sub(r'\(([^)]*)\)','',rawfilters) #removes mach3 style gcode comments
+            filtersparsed = re.sub(r';([^\n]*)\n','',filtersparsed) #removes standard ; intiated gcode comments
+            filtersparsed = re.split(r'\s(?=G)|\n|\s(?=g)|\s(?=M)', filtersparsed) #splits the gcode into elements to be added to the list
             filtersparsed = [x + ' ' for x in filtersparsed] #adds a space to the end of each line
             filtersparsed = [x.lstrip() for x in filtersparsed]
             filtersparsed = [x.replace('X ','X') for x in filtersparsed]


### PR DESCRIPTION
The target position indicator still has more fun to give. I tried stepping through some gcode which resulted in GroundControl crashing because the gcode had comments containing a 'Y' which it then tried to extract coordinates from.

I would say this is perhaps not an ideal solution but a workaround since the gcode displayed in the view gcode window has all comments stripped and thus does not resemble the original file.

Part of the problem is that the gcode is being parsed in several places so intercepting comments everywhere is cumbersome. I think we need a gcode class that instantiates a data structure on file load and provides a uniform interface to the gcode. It could have get functions for commands, x, y, and z coordinates, feed, etc. For example gcode.command(line) or gcode.x(line) which both ignore comments and a gcode.string(line) which just spits out the line. Thoughts?