### PR TITLE
Fix program crashing when no .ini file is found

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -120,14 +120,16 @@ class FrontPage(Screen, MakesmithInitFuncs):
     def moveGcodeIndex(self, dist):
         maxIndex = len(self.data.gcode)-1
         targetIndex = self.data.gcodeIndex + dist
-
-        if targetIndex < 0:
+        
+        if targetIndex < 0:             #negative index not allowed 
             self.data.gcodeIndex = 0
-        elif targetIndex > maxIndex:
+        elif maxIndex < 0:              #break if there is no data to read
+            return
+        elif targetIndex > maxIndex:    #reading past the end of the file is not allowed
             self.data.gcodeIndex = maxIndex
         else:
             self.data.gcodeIndex = targetIndex
-
+        
         gCodeLine = self.data.gcode[self.data.gcodeIndex]
         
         xTarget = 0


### PR DESCRIPTION
The program relied on having a prevous file to load a new file which caused it to crash when there is no .ini file.

Fix for #94 

@blurfl Does this fix the issue you are seeing?