### PR TITLE
Fixed z-axis position comparison by considering a "close enough" tolerance.

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -166,9 +166,9 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                 Color(1, 1, 1)
                 Line(points = (self.offsetX + self.xPosition , self.offsetY + self.yPosition , self.offsetX +  xTarget, self.offsetY  + yTarget), width = 1, group = 'gcode', dash_length = 4, dash_offset = 2)
         
-        
+        tol = 0.05 #Acceptable error in mm
         #If the zposition has changed, add indicators
-        if not zTarget == self.zPosition: 
+        if abs(zTarget - self.zPosition) >= tol:
             if zTarget - self.zPosition > 0:
                 with self.scatterObject.canvas:
                     Color(0, 1, 0)


### PR DESCRIPTION
Comparing floats using the '==' operator is subject to roundoff error and was causing erratic line color/type when displaying the cut path on the canvas. I added a tolerance which I assume is smaller than that physically achievable. See [link](http://stackoverflow.com/questions/5595425/what-is-the-best-way-to-compare-floats-for-almost-equality-in-python) for some spirited general discussion.