### PR TITLE
Make manal z-axis adjustment not trigger gcode to run

### DIFF
--- a/main.py
+++ b/main.py
@@ -243,6 +243,7 @@ class GroundControlApp(App):
             elif message[0:2] == "pt":
                 self.setTargetOnScreen(message)
             elif message[0:8] == "Message:":
+                self.previousUploadStatus = self.data.uploadFlag 
                 self.data.uploadFlag = 0
                 content = NotificationPopup(cancel = self.dismiss_popup, text = message[9:])
                 self._popup = Popup(title="Notification: ", content=content,
@@ -263,7 +264,7 @@ class GroundControlApp(App):
         
         '''
         self._popup.dismiss()
-        self.data.uploadFlag = 1
+        self.data.uploadFlag = self.previousUploadStatus #resume cutting if the machine was cutting before
     
     def setPosOnScreen(self, message):
         '''


### PR DESCRIPTION
The message popup which asks the user to adjust the z-axis depth had the effect of resuming the gcode program after the depth was changed which might not be the desired behavior