### PR TITLE
Switch to measuring dist between motors

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,10 +75,10 @@ class GroundControlApp(App):
         },
         {
             "type": "string",
-            "title": "Motor Offset Horizontal in MM",
-            "desc": "The horizontal distance from the corner of the work area to the motor.",
+            "title": "Distance Between Motors",
+            "desc": "The horizontal distance between the center of the motor shafts in MM.",
             "section": "Maslow Settings",
-            "key": "motorOffsetX"
+            "key": "motorSpacingX"
         },
         {
             "type": "string",
@@ -180,7 +180,7 @@ class GroundControlApp(App):
                                                'bedWidth':2438.4, 
                                                'bedHeight':1219.2, 
                                                'motorOffsetY':463, 
-                                               'motorOffsetX':270, 
+                                               'motorSpacingX':3035, 
                                                'sledWidth':310, 
                                                'sledHeight':139, 
                                                'sledCG':79, 
@@ -216,7 +216,7 @@ class GroundControlApp(App):
         cmdString = ("B03" 
             +" A" + str(self.data.config.get('Maslow Settings', 'bedWidth'))
             +" C" + str(self.data.config.get('Maslow Settings', 'bedHeight'))
-            +" D" + str(self.data.config.get('Maslow Settings', 'motorOffsetX'))
+            +" D" + str(self.data.config.get('Maslow Settings', 'motorSpacingX'))
             +" E" + str(self.data.config.get('Maslow Settings', 'motorOffsetY'))
             +" F" + str(self.data.config.get('Maslow Settings', 'sledWidth'))
             +" G" + str(self.data.config.get('Maslow Settings', 'sledHeight'))

--- a/main.py
+++ b/main.py
@@ -54,6 +54,13 @@ class GroundControlApp(App):
         },
         {
             "type": "string",
+            "title": "Distance Between Motors",
+            "desc": "The horizontal distance between the center of the motor shafts in MM.",
+            "section": "Maslow Settings",
+            "key": "motorSpacingX"
+        },
+        {
+            "type": "string",
             "title": "Work Area Width in MM",
             "desc": "The width of the machine working area (normally 8 feet).",
             "section": "Maslow Settings",
@@ -69,16 +76,9 @@ class GroundControlApp(App):
         {
             "type": "string",
             "title": "Motor Offset Height in MM",
-            "desc": "The vertical distance from the corner of the work area to the motor.",
+            "desc": "The vertical distance from the edge of the work area to the level of the motors.",
             "section": "Maslow Settings",
             "key": "motorOffsetY"
-        },
-        {
-            "type": "string",
-            "title": "Distance Between Motors",
-            "desc": "The horizontal distance between the center of the motor shafts in MM.",
-            "section": "Maslow Settings",
-            "key": "motorSpacingX"
         },
         {
             "type": "string",

--- a/main.py
+++ b/main.py
@@ -248,7 +248,7 @@ class GroundControlApp(App):
         cmdString = ("B03" 
             +" A" + str(self.data.config.get('Maslow Settings', 'bedWidth'))
             +" C" + str(self.data.config.get('Maslow Settings', 'bedHeight'))
-            +" D" + str(self.data.config.get('Maslow Settings', 'motorSpacingX'))
+            +" Q" + str(self.data.config.get('Maslow Settings', 'motorSpacingX'))
             +" E" + str(self.data.config.get('Maslow Settings', 'motorOffsetY'))
             +" F" + str(self.data.config.get('Maslow Settings', 'sledWidth'))
             +" G" + str(self.data.config.get('Maslow Settings', 'sledHeight'))


### PR DESCRIPTION
Switch to measuring the distance between the motors in settings instead of the motor offset distance. 

The distance between the motors is easier to measure and makes more sense to reduce the chance of confusion.

This pull request needs to be merged at the same time as a similar pull request in firmware