### PR TITLE
Add hold button to dialog

### DIFF
--- a/UIElements/notificationPopup.py
+++ b/UIElements/notificationPopup.py
@@ -12,5 +12,6 @@ class NotificationPopup(FloatLayout):
     If the text does not all fit on the display, the user can scroll it
     
     '''
-    cancel = ObjectProperty(None)
+    continueOn = ObjectProperty(None)
+    hold = ObjectProperty(None)
     text = StringProperty("")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -505,8 +505,11 @@
         BoxLayout:
             #size_hint_y: 1
             Button:
+                text: "Hold"
+                on_release: root.hold()
+            Button:
                 text: "Continue"
-                on_release: root.cancel()
+                on_release: root.continueOn()
 
 <ScrollableTextPopup>:
     BoxLayout:

--- a/main.py
+++ b/main.py
@@ -291,21 +291,31 @@ class GroundControlApp(App):
             elif message[0:8] == "Message:":
                 self.previousUploadStatus = self.data.uploadFlag 
                 self.data.uploadFlag = 0
-                content = NotificationPopup(cancel = self.dismiss_popup, text = message[9:])
+                content = NotificationPopup(cancel = self.dismiss_popup_continue, hold=self.dismiss_popup_hold , text = message[9:])
                 self._popup = Popup(title="Notification: ", content=content,
                             auto_dismiss=False, size_hint=(0.25, 0.25))
                 self._popup.open()
             else:
                 self.writeToTextConsole(message)
     
-    def dismiss_popup(self):
+    def dismiss_popup_continue(self):
         '''
         
-        Close The Pop-up
+        Close The Pop-up and continue cut
         
         '''
         self._popup.dismiss()
         self.data.uploadFlag = self.previousUploadStatus #resume cutting if the machine was cutting before
+    
+        
+    def dismiss_popup_hold(self):
+        '''
+        
+        Close The Pop-up and continue cut
+        
+        '''
+        self._popup.dismiss()
+        self.data.uploadFlag = 0 #stop cutting
     
     def setPosOnScreen(self, message):
         '''

--- a/main.py
+++ b/main.py
@@ -291,7 +291,7 @@ class GroundControlApp(App):
             elif message[0:8] == "Message:":
                 self.previousUploadStatus = self.data.uploadFlag 
                 self.data.uploadFlag = 0
-                content = NotificationPopup(cancel = self.dismiss_popup_continue, hold=self.dismiss_popup_hold , text = message[9:])
+                content = NotificationPopup(continueOn = self.dismiss_popup_continue, hold=self.dismiss_popup_hold , text = message[9:])
                 self._popup = Popup(title="Notification: ", content=content,
                             auto_dismiss=False, size_hint=(0.25, 0.25))
                 self._popup.open()


### PR DESCRIPTION
The dialog that prompts the user for action if the USB connection is lost mid cut or if the machine needs other attention used to only have the option to "Continue". This PR adds a second button which will command the machine to "Hold" so the user can take approprate action. Addresses issue #125 