### PR TITLE
Firmware version on startup

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -24,6 +24,9 @@ class SerialPortThread(MakesmithInitFuncs):
             self.serialInstance.write(message)
         except:
             print("write issue")
+
+    def _getFirmwareVersion(self):
+        self.data.gcode_queue.put('B05 ')
     
     def _setupMachineUnits(self):
         if self.data.units == "INCHES":
@@ -61,6 +64,7 @@ class SerialPortThread(MakesmithInitFuncs):
             self.lastMessageTime = time.time()
             self.data.connectionStatus = 1
             
+            self._getFirmwareVersion()
             self._setupMachineUnits()
             
             while True:


### PR DESCRIPTION
Added function and corresponding call to send B05 to machine before sending G20/21 on connection start. This should cause the firmware version to be printed in the text console but I haven't actually tested it yet.