### PR TITLE
Change the default offset to 0 for circles

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -175,8 +175,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         
         xTarget = self.xPosition
         yTarget = self.yPosition
-        iTarget = self.xPosition
-        jTarget = self.yPosition
+        iTarget = 0
+        jTarget = 0
         
         x = re.search("X(?=.)([+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
         if x:


### PR DESCRIPTION
Resolves issues with circles not rendering correctly using the GRBL-generic post processor in Fusion 360