### PR TITLE
Clicking buttons in Actions menu closes the popup automatically

### DIFF
--- a/UIElements/connectMenu.py
+++ b/UIElements/connectMenu.py
@@ -21,6 +21,9 @@ class ConnectMenu(FloatLayout, MakesmithInitFuncs):
         self.data.config.set('Maslow Settings', 'COMport', str(self.data.comport))
         self.data.config.write()
         
+        #close the parent popup
+        self.parentWidget.close()
+        
     
     def updatePorts(self, *args):
         

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -4,7 +4,7 @@ from   UIElements.scrollableTextPopup            import   ScrollableTextPopup
 from   kivy.uix.popup                            import   Popup
 
 class Diagnostics(FloatLayout, MakesmithInitFuncs):
-
+    
     def about(self):
         popupText = 'Ground Control v' + str(self.data.version) + ' allows you to control the Maslow machine. ' + \
                     'From within Ground Control, you can move the machine to where you want to begin a cut, calibrate the machine, ' + \
@@ -40,13 +40,17 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
     def returnToCenter(self):
         self.data.gcode_queue.put("G00 Z0 ")
         self.data.gcode_queue.put("G00 X0 Y0 Z0 ")
+        self.parentWidget.close()
     
     def calibrateMotors(self):
         self.data.gcode_queue.put("B01")
+        self.parentWidget.close()
         
     def calibrateChainLengths(self):
         self.data.gcode_queue.put("B02 ")
+        self.parentWidget.close()
     
     def testMotors(self):
         self.data.gcode_queue.put("B04 ")
+        self.parentWidget.close()
     

--- a/UIElements/otherFeatures.py
+++ b/UIElements/otherFeatures.py
@@ -5,7 +5,7 @@ from DataStructures.makesmithInitFuncs      import MakesmithInitFuncs
 
 class OtherFeatures(Screen, MakesmithInitFuncs):
     viewmenu = ObjectProperty(None) #make viewmenu object accessible at this scope
-    cancel   = ObjectProperty(None)
+    close    = ObjectProperty(None)
     
     def setUpData(self, data):
         self.data = data
@@ -13,3 +13,6 @@ class OtherFeatures(Screen, MakesmithInitFuncs):
         self.connectmenu.setUpData(data)
         self.diagnostics.setUpData(data)
         self.connectmenu.updatePorts()
+        self.diagnostics.parentWidget = self
+        self.viewmenu.parentWidget = self
+        self.connectmenu.parentWidget = self

--- a/UIElements/screenControls.py
+++ b/UIElements/screenControls.py
@@ -16,7 +16,7 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         '''
         content = OtherFeatures()
         content.setUpData(self.data)
-        content.cancel = self.close_actions
+        content.close = self.close_actions
         self._popup = Popup(title="Actions", content=content,
                             size_hint=(0.9, 0.9))
         self._popup.open()

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -5,14 +5,12 @@ from   kivy.uix.popup                            import   Popup
 import re
 from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
 from os                                          import    path
-from kivy.properties                             import ObjectProperty
 
 
 
 
 
 class ViewMenu(GridLayout, MakesmithInitFuncs):
-    parentWidget   = ObjectProperty(None)
     
     def openFile(self):
         '''

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -5,12 +5,14 @@ from   kivy.uix.popup                            import   Popup
 import re
 from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
 from os                                          import    path
+from kivy.properties                             import ObjectProperty
 
 
 
 
 
 class ViewMenu(GridLayout, MakesmithInitFuncs):
+    parentWidget   = ObjectProperty(None)
     
     def openFile(self):
         '''
@@ -56,6 +58,9 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         
         self.reloadGcode()
         self.dismiss_popup()
+        
+        #close the parent popup
+        self.parentWidget.close()
     
     def reloadGcode(self):
         '''
@@ -86,7 +91,13 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
             if filename is not "":
                 print "Cannot reopen gcode file. It may have been moved or deleted. To locate it or open a different file use File > Open G-code"
             self.data.gcodeFile = ""
-    
+        
+        try:
+            #close the parent popup
+            self.parentWidget.close()
+        except AttributeError:
+            pass #the parent popup does note exist to close
+        
     def show_gcode(self):
         '''
         


### PR DESCRIPTION
It was anoying to have to click "Calibrate Chain Lengths" then click
"Close". Now the actions popup closes automacially.