### PR TITLE
Change limit of maximum number of gcode lines to 20,000

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -361,7 +361,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             self.updateOneLine()
         
         #Repeat until end of file
-        if self.lineNumber < min(len(self.data.gcode),8000):
+        if self.lineNumber < min(len(self.data.gcode),20000):
             Clock.schedule_once(self.callBackMechanism)
     
     def updateGcode(self, *args):
@@ -385,8 +385,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         self.clearGcode()
         
         #Check to see if file is too large to load
-        if len(self.data.gcode) > 8000:
-            errorText = "The current file contains " + str(len(self.data.gcode)) + "lines of gcode.\nrendering all " +  str(len(self.data.gcode)) + " lines simultanously may crash the\n program, only the first 8000 lines are shown here.\nThe complete program will cut if you choose to do so."
+        if len(self.data.gcode) > 20000:
+            errorText = "The current file contains " + str(len(self.data.gcode)) + "lines of gcode.\nrendering all " +  str(len(self.data.gcode)) + " lines simultaneously may crash the\n program, only the first 20000 lines are shown here.\nThe complete program will cut if you choose to do so."
             print errorText
             #self.canv.create_text(xnow + 200, ynow - 50, text = errorText, fill = "red")
         


### PR DESCRIPTION
There was a limit on the maximum number of gcode lines loaded of 8,000.
With the new sleaker loading mechanism we can up that without the
program bogging down. The new limit is 20,000.