### PR TITLE
Fix for firmware issue #160

### DIFF
--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -47,7 +47,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
     
     def manualCalibrateChainLengths(self):
         self.data.gcode_queue.put("B06 L1900 R1900")
-        self.data.message_queue.put("Message: The machine chains have been recalibrated to length 1,900mm")
+        self.data.message_queue.put("Message: The machine chains have been recalibrate to length 1,900mm")
         self.parentWidget.close()
     
     def testMotors(self):

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -249,14 +249,23 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
     def home(self):
         
-        if self.units == "INCHES":
-            self.data.gcode_queue.put("G00 Z.25 ")
+        print "This!"
+        print self.data.config.get('Maslow Settings', 'zAxis')
+        print int(self.data.config.get('Maslow Settings', 'zAxis'))
+        
+        #if the machine has a z-axis lift it then go home
+        if int(self.data.config.get('Maslow Settings', 'zAxis')):
+            if self.units == "INCHES":
+                self.data.gcode_queue.put("G00 Z.25 ")
+            else:
+                self.data.gcode_queue.put("G00 Z5.0 ")
+            
+            self.data.gcode_queue.put("G00 X" + str(self.data.gcodeShift[0]) + " Y" + str(self.data.gcodeShift[1]) + " ")
+            
+            self.data.gcode_queue.put("G00 Z0 ")
+        #if the machine does not have a z-axis, just go home
         else:
-            self.data.gcode_queue.put("G00 Z5.0 ")
-        
-        self.data.gcode_queue.put("G00 X" + str(self.data.gcodeShift[0]) + " Y" + str(self.data.gcodeShift[1]) + " ")
-        
-        self.data.gcode_queue.put("G00 Z0 ")
+            self.data.gcode_queue.put("G00 X" + str(self.data.gcodeShift[0]) + " Y" + str(self.data.gcodeShift[1]) + " ")
         
         self.target[0] = self.data.gcodeShift[0]
         self.target[1] = self.data.gcodeShift[1]

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -248,10 +248,12 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.target[2] = 0
         
     def home(self):
+        '''
         
-        print "This!"
-        print self.data.config.get('Maslow Settings', 'zAxis')
-        print int(self.data.config.get('Maslow Settings', 'zAxis'))
+        Return the machine to it's home position. (0,0) is the default unless the 
+        origin has been moved by the user.
+        
+        '''
         
         #if the machine has a z-axis lift it then go home
         if int(self.data.config.get('Maslow Settings', 'zAxis')):

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -58,11 +58,7 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         filename = filename[0]
         fileExtension = path.splitext(filename)[1]
         
-        print "this ibt:"
-        print fileExtension
-        print self.data.config.get('Ground Control Settings', 'validExtensions')
         validExtensions = self.data.config.get('Ground Control Settings', 'validExtensions').replace(" ", "").split(',')
-        print validExtensions
         
         if fileExtension in validExtensions:
             self.data.gcodeFile = filename


### PR DESCRIPTION
When clicking the "home" button the machine asks the user to adjust the
z-axis but does not wait for the adjustment to take place as described
in firmware issue
[160](https://github.com/MaslowCNC/Firmware/issues/160) . This fixes the
problem by asssuming manual control over the z-axis if there is no
z-axis attached.