### PR TITLE
Fix z-axis issue with type bool not resolving correctly

### DIFF
--- a/main.py
+++ b/main.py
@@ -234,7 +234,7 @@ class GroundControlApp(App):
         Set the default values for the config sections.
         """
         config.setdefaults('Maslow Settings', {'COMport': '',
-                                               'zAxis': False, 
+                                               'zAxis': 0, 
                                                'zDistPerRot':3.17, 
                                                'bedWidth':2438.4, 
                                                'bedHeight':1219.2, 


### PR DESCRIPTION
Fix for an issue where if GC is launched without a settings file, the settings file it generates for itself causes the program to crash when you click the "Home" button. Fix for #201 

I would expect False to resolve as 0, but sometimes it seems not to.