### PR TITLE
Run away after manual calibration

### DIFF
--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -46,7 +46,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         self.parentWidget.close()
     
     def manualCalibrateChainLengths(self):
-        self.data.gcode_queue.put("B06 L1900 R1900")
+        self.data.gcode_queue.put("B08 ")
         self.parentWidget.close()
     
     def testMotors(self):

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -47,7 +47,6 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
     
     def manualCalibrateChainLengths(self):
         self.data.gcode_queue.put("B06 L1900 R1900")
-        self.data.message_queue.put("Message: The machine chains have been recalibrate to length 1,900mm")
         self.parentWidget.close()
     
     def testMotors(self):


### PR DESCRIPTION
Make manual chain lengths use it's own command and not be able to be run if machine is not connected