### PR TITLE
Change the label on "Define Origin" to "Set Home"

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -124,7 +124,7 @@
                 text: root.units
                 on_press: root.switchUnits()
             Button:
-                text: 'Define\n  Home'
+                text: 'Define\nHome'
                 on_release: root.moveOrigin()
                 disabled: False
         GridLayout:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -124,7 +124,7 @@
                 text: root.units
                 on_press: root.switchUnits()
             Button:
-                text: 'Define\n  Origin'
+                text: 'Define\n  Home'
                 on_release: root.moveOrigin()
                 disabled: False
         GridLayout:


### PR DESCRIPTION
This is the place the machine moves back to when you click the "Home"
button so it makes sense that it would be called "Set Home"

Anyone oposed? 