### PR TITLE
Added filter list to cover most common gcode file extensions.

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -480,7 +480,7 @@
         FileChooser:
             id: filechooser
             path: root.path
-            filters: ['*.apt','*.cnc','*.din','*.dnc','*.ecs','*.eia','*.fan','*.fnc','*.fgc','*.gc','*.gcd','*.h','*.hnc','*.i','*.m','*.min','*.mpf','*.mpr','*.nc','*.NC','*.ncc','*.ncg','*.ncp','*.ngc','*.plt','*.ply','*.rol','*.sbp','*.tap','*.xpi']
+            filters: ['*.nc','*.ngc','*.text,'*.gcode']
             FileChooserIconLayout
             FileChooserListLayout
 

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -480,6 +480,7 @@
         FileChooser:
             id: filechooser
             path: root.path
+            filters: ['*.apt','*.cnc','*.din','*.dnc','*.ecs','*.eia','*.fan','*.fnc','*.fgc','*.gc','*.gcd','*.h','*.hnc','*.i','*.m','*.min','*.mpf','*.mpr','*.nc','*.NC','*.ncc','*.ncg','*.ncp','*.ngc','*.plt','*.ply','*.rol','*.sbp','*.tap','*.xpi']
             FileChooserIconLayout
             FileChooserListLayout
 

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -480,7 +480,7 @@
         FileChooser:
             id: filechooser
             path: root.path
-            filters: ['*.nc','*.ngc','*.text,'*.gcode']
+            filters: ['*.nc','*.ngc','*.text,','*.gcode']
             FileChooserIconLayout
             FileChooserListLayout
 


### PR DESCRIPTION
Added a filter list to the kivy filechooser object based on this list of gcode file extensions [link](http://bobcadsupport.com/helpdesk/index.php?/Knowledgebase/Article/View/13/5/known-g-code-file-extensions). They are easy to add if you think of more.