### PR TITLE
Page through lines in View Gcode popup

### DIFF
--- a/UIElements/scrollableTextPopup.py
+++ b/UIElements/scrollableTextPopup.py
@@ -13,4 +13,6 @@ class ScrollableTextPopup(FloatLayout):
     
     '''
     cancel = ObjectProperty(None)
+    next = ObjectProperty(None)
+    prev = ObjectProperty(None)
     text = StringProperty("")

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -2,7 +2,6 @@ from   kivy.uix.gridlayout                       import   GridLayout
 from   UIElements.loadDialog                     import   LoadDialog
 from   UIElements.scrollableTextPopup            import   ScrollableTextPopup
 from   kivy.uix.popup                            import   Popup
-from kivy.uix.button                  import    Button
 import re
 from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
 from os                                          import    path

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -2,6 +2,7 @@ from   kivy.uix.gridlayout                       import   GridLayout
 from   UIElements.loadDialog                     import   LoadDialog
 from   UIElements.scrollableTextPopup            import   ScrollableTextPopup
 from   kivy.uix.popup                            import   Popup
+from kivy.uix.button                  import    Button
 import re
 from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
 from os                                          import    path
@@ -11,6 +12,8 @@ from os                                          import    path
 
 
 class ViewMenu(GridLayout, MakesmithInitFuncs):
+
+    page = 1
     
     def openFile(self):
         '''
@@ -92,17 +95,45 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         if len(self.data.gcode) is 0:
             popupText =  "No gcode to display"
         else:
+            if self.page<=1:
+                line = 0
+            else:
+                line = (self.page-1)*447
+                popupText = "...\n...\n...\n"
+
+            if line>len(self.data.gcode):
+                line = len(self.data.gcode)-447
+
             for lineNum, gcodeLine in enumerate(self.data.gcode):
-                if lineNum<447:
+                if lineNum>=line and lineNum<line+447:
                     popupText = popupText + gcodeLine + "\n"
-                else:
+                elif lineNum>=line+447:
                     popupText = popupText + "...\n...\n...\n"
                     break
                 
-        content = ScrollableTextPopup(cancel = self.dismiss_popup, text = popupText)
-        self._popup = Popup(title="Gcode", content=content,
+        content = ScrollableTextPopup(cancel = self.dismiss_popup,
+                                      prev = self.show_gcode_prev,
+                                      next = self.show_gcode_next,
+                                      text = popupText)
+
+        titleString = 'Gcode File: ' + self.data.gcodeFile +'\nLines: '+str(line+1)+' - '+str(lineNum)+' of '+str(len(self.data.gcode))
+        self._popup = Popup(title=titleString, content=content,
                             size_hint=(0.9, 0.9))
         self._popup.open()
+
+    def show_gcode_next(self,*args):
+
+        if (self.page)*447<len(self.data.gcode):
+            self.page += 1
+            self._popup.dismiss()
+            self.show_gcode()
+
+    def show_gcode_prev(self,*args):
+
+        if self.page > 1:
+            self.page -= 1
+            self._popup.dismiss()
+            self.show_gcode()
     
     def dismiss_popup(self):
         '''
@@ -110,4 +141,5 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         Close The Pop-up
         
         '''
+        self.page = 1
         self._popup.dismiss()

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -533,6 +533,12 @@
             size_hint_y: None
             height: dp(30)
             Button:
+                text: "Prev"
+                on_release: root.prev()
+            Button:
+                text: "Next"
+                on_release: root.next()
+            Button:
                 text: "Close"
                 on_release: root.cancel()
 


### PR DESCRIPTION
Added buttons and ability to page through lines 447 at a time. Also made the popup title more informative. This will probably conflict with PR #267 but I can easily resolve that.