### PR TITLE
Skip through Gcode by Z move

### DIFF
--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -32,6 +32,8 @@ class Data(EventDispatcher):
     comport    = StringProperty("")
     #The index of the next unread line of Gcode
     gcodeIndex = NumericProperty(0)
+    #Index of changes in z
+    zMoves     = ObjectProperty([])
     #Holds the current value of the feed rate
     feedRate   = 20
     #holds the address of the g-code file so that the gcode can be refreshed
@@ -40,6 +42,7 @@ class Data(EventDispatcher):
     currentpos = [0.0, 0.0, 0.0]
     target     = [0.0, 0.0, 0.0]
     units      = OptionProperty("MM", options=["MM", "INCHES"])
+    tolerance  = NumericProperty(0.5)
     gcodeShift = ObjectProperty([0.0,0.0])                          #the amount that the gcode has been shifted
     logger     =  Logger()                                          #the module which records the machines behavior to review later
     

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -105,8 +105,6 @@ class FrontPage(Screen, MakesmithInitFuncs):
         Move the gcode index by z moves
         '''
 
-        print(self.data.zMoves)
-
         dist = 0
 
         for index,zMove in enumerate(self.data.zMoves):
@@ -115,8 +113,6 @@ class FrontPage(Screen, MakesmithInitFuncs):
                 break
             if moves < 0 and zMove < self.data.gcodeIndex:
                 dist = self.data.zMoves[index+moves+1]-self.data.gcodeIndex
-
-        print(dist)
 
         self.moveGcodeIndex(dist)
     

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -81,9 +81,11 @@ class FrontPage(Screen, MakesmithInitFuncs):
         if newUnits == "INCHES":
             self.data.gcode_queue.put('G20 ')
             self.moveDistInput.text = str(float(self.moveDistInput.text)/25)
+            self.data.tolerance = 0.020
         else:
             self.data.gcode_queue.put('G21 ')
             self.moveDistInput.text = str(float(self.moveDistInput.text)*25)
+            self.data.tolerance = 0.5
     
     def onIndexMove(self, callback, newIndex):
         self.gcodeLineNumber = str(newIndex)
@@ -97,6 +99,26 @@ class FrontPage(Screen, MakesmithInitFuncs):
             self.holdBtn.text = "CONTINUE"
         else:
             self.holdBtn.text = "HOLD"
+
+    def moveGcodeZ(self,moves):
+        '''
+        Move the gcode index by z moves
+        '''
+
+        print(self.data.zMoves)
+
+        dist = 0
+
+        for index,zMove in enumerate(self.data.zMoves):
+            if moves > 0 and zMove > self.data.gcodeIndex:
+                dist = self.data.zMoves[index+moves-1]-self.data.gcodeIndex
+                break
+            if moves < 0 and zMove < self.data.gcodeIndex:
+                dist = self.data.zMoves[index+moves+1]-self.data.gcodeIndex
+
+        print(dist)
+
+        self.moveGcodeIndex(dist)
     
     def moveGcodeIndex(self, dist):
         '''

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -129,9 +129,11 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                     zList.append(z)
                     if len(zList) > 1:
                         if not self.isClose(float(zList[-1].groups()[0]),float(zList[-2].groups()[0])):
-                            self.data.zMoves.append(index)
+                            self.data.zMoves.append(index-1)
                     else:
                         self.data.zMoves.append(index)
+
+            print(self.data.zMoves)
 
         except:
             if filename is not "":

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -121,6 +121,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             filterfile.close() #closes the filter save file
 
             #Find gcode indicies of z moves
+            self.data.zMoves = [0]
             zList = []
             for index, line in enumerate(self.data.gcode):
                 z = re.search("Z(?=.)([+-]?([0-9]*)(\.([0-9]+))?)",line)

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -88,6 +88,9 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         if keycode[1] == self.data.config.get('Ground Control Settings', 'zoomOut'):
             mat = Matrix().scale(1+scaleFactor, 1+scaleFactor, 1)
             self.scatterInstance.apply_transform(mat, anchor)
+
+    def isClose(self, a, b):
+        return abs(a-b) <= self.data.tolerance
     
     def reloadGcode(self, *args):
         '''
@@ -116,7 +119,21 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             self.data.gcode = filtersparsed
             
             filterfile.close() #closes the filter save file
-        except:
+
+            #Find gcode indicies of z moves
+            zList = []
+            for index, line in enumerate(self.data.gcode):
+                z = re.search("Z(?=.)([+-]?([0-9]*)(\.([0-9]+))?)",line)
+                if z:
+                    zList.append(z)
+                    if len(zList) > 1:
+                        if not self.isClose(float(zList[-1].groups()[0]),float(zList[-2].groups()[0])):
+                            self.data.zMoves.append(index)
+                    else:
+                        self.data.zMoves.append(index)
+
+        except Exception, e:
+            print(e)
             if filename is not "":
                 self.data.message_queue.put("Message: Cannot reopen gcode file. It may have been moved or deleted. To locate it or open a different file use Actions > Open G-code")
             self.data.gcodeFile = ""
@@ -335,7 +352,6 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             if x:
                 xTarget = float(x.groups()[0]) + self.data.gcodeShift[0]
                 gCodeLine = gCodeLine[0:x.start()+1] + str(xTarget) + gCodeLine[x.end():]
-            
             
             y = re.search("Y(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if y:

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -133,8 +133,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                     else:
                         self.data.zMoves.append(index)
 
-        except Exception, e:
-            print(e)
+        except:
             if filename is not "":
                 self.data.message_queue.put("Message: Cannot reopen gcode file. It may have been moved or deleted. To locate it or open a different file use Actions > Open G-code")
             self.data.gcodeFile = ""

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -148,18 +148,17 @@
             height: dp(30)
             #disabled: not app.data.connectionStatus
             Button:
-                text: "<<10"
-                on_press: root.moveGcodeIndex(-10)
+                text: "<Z"
+                on_press: root.moveGcodeZ(-1)
             Button:
                 text: "<1"
                 on_press: root.moveGcodeIndex(-1)
-
             Button:
                 text: "1>"
                 on_press: root.moveGcodeIndex(1)
             Button:
-                text: "10>>"
-                on_press: root.moveGcodeIndex(10)
+                text: "Z>"
+                on_press: root.moveGcodeZ(1)
         BoxLayout:
             orentation: 'horizontal'
             size_hint: None, None


### PR DESCRIPTION
See discussion in issue #225. This seems to work in ground control but I haven't actually tested it with hardware. Added a function `isClose` for comparing positions with a tolerance that changes based on unit system. The default tolerances may need to be adjusted. The logic in the `moveGcodeZ` could probably be improved.