### PR TITLE
Make return to center not lower bit

### DIFF
--- a/UIElements/runMenu.py
+++ b/UIElements/runMenu.py
@@ -20,7 +20,6 @@ class RunMenu(FloatLayout):
             
             self.data.gcode_queue.put("G00 X0.0 Y0.0 ")
             
-            self.data.gcode_queue.put("G00 Z0 ")
         #if the machine does not have a z-axis, just go home
         else:
             self.data.gcode_queue.put("G00 X0.0 Y0.0 ")


### PR DESCRIPTION
I've found that I very rarely am happy that the bit has been lowered
once the machine has returned to the center.