### PR TITLE
Don't set axis pos to zero with each when calibrating lengths

### DIFF
--- a/UIElements/calibrateLengthsPopup.py
+++ b/UIElements/calibrateLengthsPopup.py
@@ -13,26 +13,22 @@ class CalibrateLengthsPopup(GridLayout):
     
     def LeftCW(self):
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 L.5 ")
         self.data.gcode_queue.put("G90 ")
     
     def LeftCCW(self):
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 L-.5 ")
         self.data.gcode_queue.put("G90 ")
         
     def RightCW(self):
         print "right CW"
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 R-.5 ")
         self.data.gcode_queue.put("G90 ")
     
     def RightCCW(self):
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 R.5 ")
         self.data.gcode_queue.put("G90 ")
     

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -43,28 +43,24 @@ class MeasureMachinePopup(GridLayout):
     def LeftCW(self):
         print "left CW"
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 L.5 ")
         self.data.gcode_queue.put("G90 ")
     
     def LeftCCW(self):
         print "left CCW"
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 L-.5 ")
         self.data.gcode_queue.put("G90 ")
         
     def RightCW(self):
         print "right CW"
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 R-.5 ")
         self.data.gcode_queue.put("G90 ")
     
     def RightCCW(self):
         print "right CCW"
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B06 L0 R0 ")
         self.data.gcode_queue.put("B09 R.5 ")
         self.data.gcode_queue.put("G90 ")
     


### PR DESCRIPTION
The motors were acting jittery when orentating one sprocket tooth to 12
o'clock because the axis position was being reset to 0 which was
triggering the PID loop to compensate. Setting them to zero with each
move is not needed (and doesn't make sense)