### PR TITLE
Make logger write to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.ini
 *ENV
+log.txt

--- a/DataStructures/logger.py
+++ b/DataStructures/logger.py
@@ -6,12 +6,15 @@ behavior.
 '''
 
 from DataStructures.makesmithInitFuncs       import MakesmithInitFuncs
+import threading
 
 
 class Logger(MakesmithInitFuncs):
     
     errorValues = []
     recordingPositionalErrors = False 
+    
+    messageBuffer = ""
     
     #clear the old log file
     with open("log.txt", "a") as logFile:
@@ -20,15 +23,29 @@ class Logger(MakesmithInitFuncs):
     def writeToLog(self, message):
         '''
         
-        Writes a message into the log.
+        Writes a message into the log
+        
+        Actual writing is done in a separate thread to no lock up the UI because file IO is 
+        way slow
         
         '''
-        #print "write to log: "
-        #print message
         
-        with open("log.txt", "a") as logFile:
-            logFile.write(message)
+        self.messageBuffer = self.messageBuffer + message
+        
+        if len(self.messageBuffer) > 500:
+            t = threading.Thread(target=self.writeToFile, args=(self.messageBuffer))
+            self.messageBuffer = ""
     
+    def writeToFile(self, toWrite):
+        '''
+        
+        Write to the log file
+        
+        '''
+        with open("log.txt", "a") as logFile:
+            logFile.write(toWrite)
+        
+        
     def writeErrorValueToLog(self, error):
         '''
         

--- a/DataStructures/logger.py
+++ b/DataStructures/logger.py
@@ -13,13 +13,21 @@ class Logger(MakesmithInitFuncs):
     errorValues = []
     recordingPositionalErrors = False 
     
+    #clear the old log file
+    with open("log.txt", "a") as logFile:
+            logFile.truncate()
+    
     def writeToLog(self, message):
         '''
         
-        Writes an error message into the log.
+        Writes a message into the log.
         
         '''
-        pass
+        #print "write to log: "
+        #print message
+        
+        with open("log.txt", "a") as logFile:
+            logFile.write(message)
     
     def writeErrorValueToLog(self, error):
         '''


### PR DESCRIPTION
Writes all messages from the machine to the file log.txt in the Ground Control folder