### PR TITLE
Define inital state during calibration

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -43,7 +43,19 @@ class MeasureMachinePopup(GridLayout):
 	def begin(self):
 		print "begin fcn ran"
 		self.carousel.load_next()
-	
+    
+    def defineInitialState(self):
+        '''
+        
+        Ensure that the calibration process begins with known initial conditions for where the axis
+        think that they are are by setting both to zero. This prevents strange behavior when rotating
+        each sprocket to 12:00
+        
+        '''
+        print "define initial state"
+        self.data.gcode_queue.put("B06 L0 R0 ");
+        self.carousel.load_next()
+    
     def LeftCW(self):
         print "left CW"
         self.data.gcode_queue.put("G91 ")

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -39,7 +39,11 @@ class MeasureMachinePopup(GridLayout):
         if self.carousel.index == 9:
             #Final finish step
             self.goFwdBtn.disabled = True
-        
+    
+	def begin(self):
+		print "begin fcn ran"
+		self.carousel.load_next()
+	
     def LeftCW(self):
         print "left CW"
         self.data.gcode_queue.put("G91 ")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -714,7 +714,7 @@
                     text: 'The controls you will need\nfor each step will be on here\non the right'
                 Button:
                     text: "Begin"
-                    on_release: carousel.load_next()
+                    on_release: root.begin()
                 Label:
         GridLayout:
             cols: 2

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -714,7 +714,7 @@
                     text: 'The controls you will need\nfor each step will be on here\non the right'
                 Button:
                     text: "Begin"
-                    on_release: root.begin()
+                    on_release: root.defineInitialState()
                 Label:
         GridLayout:
             cols: 2


### PR DESCRIPTION
Defne the axis initial position when the "begin" button is presed during calibration. This prevents unexpeted behavior while orentating the gears