### PR TITLE
Add ranchers calibration process suggestions

### DIFF
--- a/UIElements/calibrateLengthsPopup.py
+++ b/UIElements/calibrateLengthsPopup.py
@@ -32,6 +32,10 @@ class CalibrateLengthsPopup(GridLayout):
         self.data.gcode_queue.put("B09 R.5 ")
         self.data.gcode_queue.put("G90 ")
     
+    def stop(self):
+        self.data.quick_queue.put("!") 
+        with self.data.gcode_queue.mutex:
+            self.data.gcode_queue.queue.clear()
     
     def setZero(self):
         #mark that the sprockets are straight up

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -46,7 +46,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         self.popupContent      = CalibrateLengthsPopup(done=self.dismissMeasureMachinePopup)
         self.popupContent.data = self.data
         self._popup = Popup(title="Calibrate Chain Lengths", content=self.popupContent,
-                            size_hint=(0.85, 0.95))
+                            size_hint=(0.85, 0.95), auto_dismiss = False)
         self._popup.open()
     
     def manualCalibrateChainLengths(self):
@@ -79,7 +79,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         self.popupContent      = MeasureMachinePopup(done=self.dismissMeasureMachinePopup)
         self.popupContent.data = self.data
         self._popup = Popup(title="Setup Machine Dimensions", content=self.popupContent,
-                            size_hint=(0.85, 0.95))
+                            size_hint=(0.85, 0.95), auto_dismiss = False)
         self._popup.open()
     
     def dismissMeasureMachinePopup(self):

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -239,6 +239,8 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
         '''
         
+        self.data.gcode_queue.put("G90  ")
+        
         #if the machine has a z-axis lift it then go home
         if int(self.data.config.get('Maslow Settings', 'zAxis')):
             if self.units == "INCHES":

--- a/UIElements/runMenu.py
+++ b/UIElements/runMenu.py
@@ -12,6 +12,9 @@ class RunMenu(FloatLayout):
         App.get_running_app().stop()
     
     def returnToCenter(self):
+        
+        self.data.gcode_queue.put("G90  ")
+        
         if int(self.data.config.get('Maslow Settings', 'zAxis')):
             if self.data.units == "INCHES":
                 self.data.gcode_queue.put("G00 Z.25 ")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -818,7 +818,7 @@
                 cols: 1
                 size_hint_x: leftCol
                 Label:
-                    text: "Unhook the cotter pin from the sled\n\nRetract the chain until it hangs down from the motor to the height of the top of the 4x8 sheet, then click Measure\n\nThis measurement is not critical for the internal mathematics\nit simply moves the center point of the plywood up and down"
+                    text: "Unhook the cotter pin from the sled\n\nRetract the chain until it hangs down from the motor to the height of the top of the 4x8 sheet, then click Measure\n\nBe careful that the chain hangs straight down, and is not caught on the chain tensioner to get an accurate measurement\n\nThis measurement is not critical for the internal mathematics\nit simply moves the center point of the plywood up and down"
                     size_hint_x: leftCol
                 Image:
                     source: "./Documentation/Calibrate Machine Dimensions/Measure Motor Height.jpg"

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -750,7 +750,7 @@
             GridLayout:
                 cols: 1
                 Label:
-                    text: "Rather than using a tape measure to measure the spacing between the motors, we're going to use the chain.\n\nHook the first link from the left chain over the top tooth on the left motor\n\nThen, use the buttons to the right to extend the chain until it can reach the right motor.\nHook the third link on the right motor's 12:00 tooth as shown in the picture below\n\nPull the chain right by pressing Pull Chain Tight. You can use this button repeatedly if needed\n\nPress Measure when the chain is taught"
+                    text: "Rather than using a tape measure to measure the spacing between the motors, we're going to use the chain.\n\nHook the first link from the left chain over the top tooth on the left motor\n\nThen, use the buttons to the right to extend the chain until it can reach the right motor.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way\n\nHook the third link on the right motor's 12:00 tooth as shown in the picture below\n\nPull the chain right by pressing Pull Chain Tight. You can use this button repeatedly if needed\n\nPress Measure when the chain is taught"
                     size_hint_x: leftCol
                 GridLayout:
                     cols: 3
@@ -1030,7 +1030,7 @@
                 cols: 1
                 size_hint_x: leftCol
                 Label:
-                    text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of each chain on the vertical tooth of each sprocket\n as shown in the picture below. Then press Calibrate Chain Lengths\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Finish"
+                    text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of each chain on the vertical tooth of each sprocket\n as shown in the picture below. Then press Calibrate Chain Lengths\n\nThe correct length of first the left and then the right chain will be measured out\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way\n\nOnce both chains are finished attach the sled, then press Finish"
                     size_hint_x: leftCol
                 GridLayout:
                     cols: 3
@@ -1047,6 +1047,9 @@
                 Button:
                     text: 'Calibrate\nChain Lengths'
                     on_release: root.calibrateChainLengths()
+                Button:
+                    text: 'Stop Motor'
+                    on_release: root.stop()
                 Button:
                     text: 'Finish'
                     on_release: root.done()


### PR DESCRIPTION
-Add warning about chain wrapping to both first step of machine calibration process and chain length calibration process
-Add a 'stop' button to chain length calibration process
-Make sure that the 'home' and 'return to center' commands use the G90 command instead of the G91 command after calibration
-Add warning about chain on chain tensioner when doing the vertical measurement 