### PR TITLE
Avoid invalid list indexing in case no data loaded and negative index

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -124,10 +124,10 @@ class FrontPage(Screen, MakesmithInitFuncs):
         targetIndex = self.data.gcodeIndex + dist
         
         #check to see if we are still within the length of the file
-        if targetIndex < 0:             #negative index not allowed 
-            self.data.gcodeIndex = 0
-        elif maxIndex < 0:              #break if there is no data to read
+        if maxIndex < 0:              #break if there is no data to read
             return
+        elif targetIndex < 0:             #negative index not allowed 
+            self.data.gcodeIndex = 0
         elif targetIndex > maxIndex:    #reading past the end of the file is not allowed
             self.data.gcodeIndex = maxIndex
         else:


### PR DESCRIPTION
If both first two if statements apply returning because of empty list (maxIndex < 0) has to be executed.