### PR TITLE
Fix issue with random circles being cut

### DIFF
--- a/main.py
+++ b/main.py
@@ -247,6 +247,10 @@ class GroundControlApp(App):
         Load User Settings
         '''
         
+        self.config.set('Advanced Settings', 'truncate', 0)
+        self.config.set('Advanced Settings', 'digits', 4)
+        self.config.write()
+        
         self.data.comport = self.config.get('Maslow Settings', 'COMport')
         self.data.gcodeFile = self.config.get('Maslow Settings', 'openFile')
         offsetX = float(self.config.get('Advanced Settings', 'homeX'))
@@ -304,8 +308,8 @@ class GroundControlApp(App):
                                                  'zEncoderSteps':7560.0,
                                                  'homeX': 0.0,
                                                  'homeY': 0.0,
-                                                 'truncate': 1,
-                                                 'digits' : 2})
+                                                 'truncate': 0,
+                                                 'digits' : 4})
         
         config.setdefaults('Ground Control Settings', {'zoomIn': "pageup",
                                                  'validExtensions':".nc, .ngc, .text, .gcode",


### PR DESCRIPTION
There was an issue with random circles being cut as full circles instead of partial circles, the solution was to turn off the automatic truncating of the number of digits being sent to the firmware.

Unfortunately because the settings file is only created the FIRST time ground control is installed the only to make the change for existing Ground Control installs is to force the setting value to false every time Ground Control is launched, so for the next few weeks to use the very useful feature of truncating the number of digits sent to the machine you will have to go into settings and manually enable it each time GC launches. Once most peoples installs have been fixed, we'll turn off the auto disable on launch part.