### PR TITLE
Modify Simulation for Chain Slippage

### DIFF
--- a/Simulation/kinematics.py
+++ b/Simulation/kinematics.py
@@ -17,6 +17,8 @@ class Kinematics():
     machineHeight = 1219.2                              #this is 4 feet in mm
     machineWidth  = 2438.4                              #this is 8 feet in mm
     motorOffsetY  = 463.0                               #vertical distance from the corner of the work area to the sprocket center
+    chain1Offset  = 0                                   #number of links +,- that have slipped
+    chain2Offset  = 0                                   #number of links +,- that have slipped
 
     x = 2708.4
     y = 270
@@ -286,6 +288,11 @@ class Kinematics():
         Take the chain lengths and return an XY position
 
         '''
+
+        # apply any offsets for slipped links
+        chainALength = chainALength + (self.chain1Offset * self.R)
+        chainBLength = chainBLength + (self.chain2Offset * self.R)
+
         xGuess = -10
         yGuess = 0
 

--- a/Simulation/simulationCanvas.py
+++ b/Simulation/simulationCanvas.py
@@ -32,6 +32,8 @@ class SimulationCanvas(GridLayout):
         self.motorVerticalError.bind(value=self.onSliderChange)
         self.sledMountSpacingError.bind(value=self.onSliderChange)
         self.vertBitDist.bind(value=self.onSliderChange)
+        self.leftChainOffset.bind(value=self.onSliderChange)
+        self.rightChainOffset.bind(value=self.onSliderChange)
 
         self.vertCGDist.bind(value=self.onSliderChange)
         self.gridSize.bind(value=self.onSliderChange)
@@ -69,6 +71,8 @@ class SimulationCanvas(GridLayout):
         self.sledMountSpacingError.value = 0
         self.vertBitDist.value = 0
         self.vertCGDist.value = 0
+        self.leftChainOffset.value = 0
+        self.rightChainOffset.value = 0
         self.gridSize.value=150
 
     def recompute(self):
@@ -91,7 +95,7 @@ class SimulationCanvas(GridLayout):
         self.listOfDistortedPoints = []
         self.pointIndex = 0
         self.verticalPoints   = range(int(int(topBottomBound/self.gridSize.value)*self.gridSize.value), -topBottomBound, -1 * int(self.gridSize.value))
-        self.horizontalPoints = range(0, leftRigthBound, int(self.gridSize.value))
+        self.horizontalPoints = range(int(int(leftRigthBound/self.gridSize.value)*self.gridSize.value), -leftRigthBound, -1 * int(self.gridSize.value))
 
         #self.doSpecificCalculation()
 
@@ -128,26 +132,10 @@ class SimulationCanvas(GridLayout):
         for i in range(0, len(self.verticalPoints)):
             points = []
 
-            for j in range(len(self.horizontalPoints)-1,0,-1):
-                point = self.listOfPointsToPlot[j + i*len(self.horizontalPoints)]
-                points.append(self.bedWidth/2-point[0])
-                points.append(point[1]+self.bedHeight/2)
             for j in range(0,len(self.horizontalPoints)):
                 point = self.listOfPointsToPlot[j + i*len(self.horizontalPoints)]
                 points.append(point[0]+self.bedWidth/2)
                 points.append(point[1]+self.bedHeight/2)
-
-            with self.scatterInstance.canvas:
-                Color(0,0,1)
-                Line(points=points)
-
-        for i in range(len(self.horizontalPoints)-1,0,-1):
-            points = []
-            for j in range(0,len(self.listOfPointsToPlot),len(self.horizontalPoints)):
-                point = self.listOfPointsToPlot[j+i]
-                points.append(self.bedWidth/2-point[0])
-                points.append(point[1]+self.bedHeight/2)
-
 
             with self.scatterInstance.canvas:
                 Color(0,0,1)
@@ -171,26 +159,10 @@ class SimulationCanvas(GridLayout):
         for i in range(0, len(self.verticalPoints)):
             points = []
 
-            for j in range(len(self.horizontalPoints)-1,0,-1):
-                point = self.listOfDistortedPoints[j + i*len(self.horizontalPoints)]
-                points.append(self.bedWidth/2-point[0])
-                points.append(point[1]+self.bedHeight/2)
             for j in range(0,len(self.horizontalPoints)):
                 point = self.listOfDistortedPoints[j + i*len(self.horizontalPoints)]
                 points.append(point[0]+self.bedWidth/2)
                 points.append(point[1]+self.bedHeight/2)
-
-            with self.scatterInstance.canvas:
-                Color(1,0,0)
-                Line(points=points)
-
-        for i in range(len(self.horizontalPoints)-1,0,-1):
-            points = []
-            for j in range(0,len(self.listOfDistortedPoints),len(self.horizontalPoints)):
-                point = self.listOfDistortedPoints[j+i]
-                points.append(self.bedWidth/2-point[0])
-                points.append(point[1]+self.bedHeight/2)
-
 
             with self.scatterInstance.canvas:
                 Color(1,0,0)
@@ -213,10 +185,6 @@ class SimulationCanvas(GridLayout):
         for i in range(0, len(self.verticalPoints)):
             points = []
 
-            for j in range(len(self.horizontalPoints)-1,0,-1):
-                point = self.listOfPointsPlotted[j + i*len(self.horizontalPoints)]
-                points.append(self.bedWidth/2-point[0])
-                points.append(point[1]+self.bedHeight/2)
             for j in range(0,len(self.horizontalPoints)):
                 point = self.listOfPointsPlotted[j + i*len(self.horizontalPoints)]
                 points.append(point[0]+self.bedWidth/2)
@@ -226,17 +194,6 @@ class SimulationCanvas(GridLayout):
                 Color(0,1,0)
                 Line(points=points)
 
-        for i in range(len(self.horizontalPoints)-1,0,-1):
-            points = []
-            for j in range(0,len(self.listOfPointsPlotted),len(self.horizontalPoints)):
-                point = self.listOfPointsPlotted[j+i]
-                points.append(self.bedWidth/2-point[0])
-                points.append(point[1]+self.bedHeight/2)
-
-
-            with self.scatterInstance.canvas:
-                Color(0,1,0)
-                Line(points=points)
 
         for i in range(0, len(self.horizontalPoints)):
             points = []
@@ -280,6 +237,12 @@ class SimulationCanvas(GridLayout):
 
         self.distortedKinematics.h3 = self.correctKinematics.h3 + self.vertCGDist.value
         self.vertCGDistLabel.text = "Vert Dist\nBit to CG Error: " + str(int(self.vertCGDist.value)) + "mm"
+
+        self.distortedKinematics.chain1Offset = int(self.leftChainOffset.value)
+        self.leftChainOffsetLabel.text = "Left Chain\nSlipped Links: " + str(int(self.leftChainOffset.value)) + "links"
+
+        self.distortedKinematics.chain2Offset = int(self.rightChainOffset.value)
+        self.rightChainOffsetLabel.text = "Right Chain\nSlipped Links: " + str(int(self.rightChainOffset.value)) + "links"
 
         self.machineLabel.text = "distance between sled attachments ideal: "+str(self.correctKinematics.l)+" actual: "+str(self.distortedKinematics.l)+"mm\nvertical distance between sled attachments and bit ideal: "+str(self.correctKinematics.s)+" actual: "+str(self.distortedKinematics.s)+"mm\nvertical distance between sled attachments and CG ideal: "+str(self.correctKinematics.h3+self.correctKinematics.s)+" actual: "+str(self.distortedKinematics.h3+self.distortedKinematics.s)+"mm\ndistance between motors ideal: "+str(self.correctKinematics.D)+" actual: "+str(self.distortedKinematics.D)+"mm"
 

--- a/Simulation/testPoint.py
+++ b/Simulation/testPoint.py
@@ -50,13 +50,10 @@ class TestPoint(GridLayout):
         with self.targetCanvas:
             Color(0, 0, 1)
             Line(circle=(self.xLocation+self.bedWidth/2, self.yLocation+self.bedHeight/2, radius-3))
-            Line(circle=(self.bedWidth/2-self.xLocation, self.yLocation+self.bedHeight/2, radius-3))
             Color(0, 1, 0)
             Line(circle=(correctPosX+self.bedWidth/2, correctPosY+self.bedHeight/2, radius-2))
-            Line(circle=(self.bedWidth/2-correctPosX, correctPosY+self.bedHeight/2, radius-2))
             Color(1, 0, 0)
             Line(circle=(distortedPosX+self.bedWidth/2, distortedPosY+self.bedHeight/2, radius))
-            Line(circle=(+self.bedWidth/2-distortedPosX, distortedPosY+self.bedHeight/2, radius))
 
         print 'ideal, {:+7.2f}, {:+7.2f}  pos, {:+7.2f}, {:+7.2f}  Error, {:7.2f}, {:7.2f}  Distortion, {:7.2f}, {:7.2f}'.format(self.xLocation,self.yLocation,correctPosX,correctPosY,self.xLocation-correctPosX,self.yLocation-correctPosY,correctPosX-distortedPosX,correctPosY-distortedPosY)
         distortedPoint = (distortedPosX, distortedPosY)

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1062,11 +1062,15 @@
     scatterInstance:scatterInstance
     vertBitDist:vertBitDist
     vertCGDist:vertCGDist
+    leftChainOffset:leftChainOffset
+    rightChainOffset:rightChainOffset
     motorSpacingErrorLabel:motorSpacingErrorLabel
     motorVerticalErrorLabel:motorVerticalErrorLabel
     sledMountSpacingErrorLabel:sledMountSpacingErrorLabel
     vertBitDistLabel:vertBitDistLabel
     vertCGDistLabel:vertCGDistLabel
+    leftChainOffsetLabel:leftChainOffsetLabel
+    rightChainOffsetLabel:rightChainOffsetLabel
     machineLabel:machineLabel
     gridSize:gridSize
     gridSizeLabel:gridSizeLabel
@@ -1139,6 +1143,22 @@
                 max:300
                 value: 300
                 id: gridSize
+            Label:
+                text: "Left Chain\nSlipped Links: 0links"
+                id: leftChainOffsetLabel
+            Slider:
+                min: -10
+                max:10
+                value: 0
+                id: leftChainOffset
+            Label:
+                text: "Right Chain\nSlipped Links: 0links"
+                id: rightChainOffsetLabel
+            Slider:
+                min: -10
+                max:10
+                value: 0
+                id: rightChainOffset
 
             Button:
                 text: "Reset All"


### PR DESCRIPTION
Simulate what it would look like if the chain position is off by a specified number of links.

This error is not symmetrical so it required running the simulation on the full work area, not just the left side and mirroring for the right.  This does result in taking twice as long to generate a simulation, but I think it is worth for the added capability.