### PR TITLE
Fix issue #383

### DIFF
--- a/UIElements/notificationPopup.py
+++ b/UIElements/notificationPopup.py
@@ -13,5 +13,4 @@ class NotificationPopup(FloatLayout):
     
     '''
     continueOn = ObjectProperty(None)
-    hold = ObjectProperty(None)
     text = StringProperty("")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -516,9 +516,6 @@
         BoxLayout:
             #size_hint_y: 1
             Button:
-                text: "Hold"
-                on_release: root.hold()
-            Button:
                 text: "Continue"
                 on_release: root.continueOn()
 

--- a/main.py
+++ b/main.py
@@ -538,7 +538,7 @@ class GroundControlApp(App):
                     self._popup.dismiss()                                           #close any open popup
                 except:
                     pass                                                            #there wasn't a popup to close
-                content = NotificationPopup(continueOn = self.dismiss_popup_continue, hold=self.dismiss_popup_hold , text = message[9:])
+                content = NotificationPopup(continueOn = self.dismiss_popup_continue, text = message[9:])
                 self._popup = Popup(title="Notification: ", content=content,
                             auto_dismiss=False, size_hint=(0.35, 0.35))
                 self._popup.open()


### PR DESCRIPTION
When kinematics.cpp sends “Message: Unable to find valid machine
position. Please calibrate chain lengths.”, main.py puts up a
NotificationPopup box with continueOn and hold buttons. The hold button
is inappropriate, and causes user confusion by putting the machine into
a state where the controls seem unresponsive.
See discusson on forum.
Since the NotificationPopup seems only to be used for this one purpose,
I think we should remove the Hold button from it to prevent the confusion.