### PR TITLE
Split kinematics settings from motor settings

### DIFF
--- a/Simulation/simulationCanvas.py
+++ b/Simulation/simulationCanvas.py
@@ -103,7 +103,7 @@ class SimulationCanvas(GridLayout):
         self.verticalPoints   = range(int(int(topBottomBound/self.gridSize.value)*self.gridSize.value), -topBottomBound, -1 * int(self.gridSize.value))
         self.horizontalPoints = range(int(int(leftRigthBound/self.gridSize.value)*self.gridSize.value), -leftRigthBound, -1 * int(self.gridSize.value))
 
-        #self.doSpecificCalculation()
+        self.doSpecificCalculation()
 
         for j in self.verticalPoints:
             for i in self.horizontalPoints:

--- a/main.py
+++ b/main.py
@@ -437,6 +437,13 @@ class GroundControlApp(App):
     
     def push_settings_to_machine(self, *args):
         
+        
+        #Push kinematics settings to machine
+        if self.data.config.get('Advanced Settings', 'kinematicsType') == 'Quadrilateral':
+            kinematicsType = 1
+        else:
+            kinematicsType = 2
+        
         cmdString = ("B03" 
             +" A" + str(self.data.config.get('Maslow Settings', 'bedWidth'))
             +" C" + str(self.data.config.get('Maslow Settings', 'bedHeight'))
@@ -445,18 +452,14 @@ class GroundControlApp(App):
             +" F" + str(self.data.config.get('Maslow Settings', 'sledWidth'))
             +" R" + str(self.data.config.get('Maslow Settings', 'sledHeight'))
             +" H" + str(self.data.config.get('Maslow Settings', 'sledCG'))
-            +" I" + str(self.data.config.get('Maslow Settings', 'zAxis'))
-            +" J" + str(self.data.config.get('Advanced Settings', 'encoderSteps'))
-            +" K" + str(self.data.config.get('Advanced Settings', 'gearTeeth'))
-            +" M" + str(self.data.config.get('Advanced Settings', 'chainPitch'))
-            +" N" + str(self.data.config.get('Maslow Settings'  , 'zDistPerRot'))
-            +" P" + str(self.data.config.get('Advanced Settings', 'zEncoderSteps'))
+            +" Y" + str(kinematicsType)
+            +" Z" + str(self.data.config.get('Advanced Settings', 'rotationRadius'))
             + " "
         )
         
         self.data.gcode_queue.put(cmdString)
         
-        #Split the settings push into two so that it doesn't exceed the maximum line length
+        #Push motor configuration settings to machine
         
         
         if int(self.data.config.get('Advanced Settings', 'enablePosPIDValues')) == 1:
@@ -477,26 +480,26 @@ class GroundControlApp(App):
             KiV = 1
             KdV = 0
         
-        if self.data.config.get('Advanced Settings', 'kinematicsType') == 'Quadrilateral':
-            kinematicsType = 1
-            print "quadrilateral recognized"
-        else:
-            kinematicsType = 2
-            print "triangular kinematics recognized"
         
-        cmdString = ("B03" 
+        
+        cmdString = ("B12" 
+            +" I" + str(self.data.config.get('Maslow Settings', 'zAxis'))
+            +" J" + str(self.data.config.get('Advanced Settings', 'encoderSteps'))
+            +" K" + str(self.data.config.get('Advanced Settings', 'gearTeeth'))
+            +" M" + str(self.data.config.get('Advanced Settings', 'chainPitch'))
+            +" N" + str(self.data.config.get('Maslow Settings'  , 'zDistPerRot'))
+            +" P" + str(self.data.config.get('Advanced Settings', 'zEncoderSteps'))
             +" S" + str(KpPos)
             +" T" + str(KiPos)
             +" U" + str(KdPos)
             +" V" + str(KpV)
             +" W" + str(KiV)
             +" X" + str(KdV)
-            +" Y" + str(kinematicsType)
-            +" Z" + str(self.data.config.get('Advanced Settings', 'rotationRadius'))
             + " "
         )
         
         self.data.gcode_queue.put(cmdString)
+        
     
     '''
     

--- a/main.py
+++ b/main.py
@@ -438,27 +438,6 @@ class GroundControlApp(App):
     def push_settings_to_machine(self, *args):
         
         
-        #Push kinematics settings to machine
-        if self.data.config.get('Advanced Settings', 'kinematicsType') == 'Quadrilateral':
-            kinematicsType = 1
-        else:
-            kinematicsType = 2
-        
-        cmdString = ("B03" 
-            +" A" + str(self.data.config.get('Maslow Settings', 'bedWidth'))
-            +" C" + str(self.data.config.get('Maslow Settings', 'bedHeight'))
-            +" Q" + str(self.data.config.get('Maslow Settings', 'motorSpacingX'))
-            +" E" + str(self.data.config.get('Maslow Settings', 'motorOffsetY'))
-            +" F" + str(self.data.config.get('Maslow Settings', 'sledWidth'))
-            +" R" + str(self.data.config.get('Maslow Settings', 'sledHeight'))
-            +" H" + str(self.data.config.get('Maslow Settings', 'sledCG'))
-            +" Y" + str(kinematicsType)
-            +" Z" + str(self.data.config.get('Advanced Settings', 'rotationRadius'))
-            + " "
-        )
-        
-        self.data.gcode_queue.put(cmdString)
-        
         #Push motor configuration settings to machine
         
         
@@ -500,7 +479,28 @@ class GroundControlApp(App):
         
         self.data.gcode_queue.put(cmdString)
         
-    
+        #Push kinematics settings to machine
+        if self.data.config.get('Advanced Settings', 'kinematicsType') == 'Quadrilateral':
+            kinematicsType = 1
+        else:
+            kinematicsType = 2
+        
+        cmdString = ("B03" 
+            +" A" + str(self.data.config.get('Maslow Settings', 'bedWidth'))
+            +" C" + str(self.data.config.get('Maslow Settings', 'bedHeight'))
+            +" Q" + str(self.data.config.get('Maslow Settings', 'motorSpacingX'))
+            +" E" + str(self.data.config.get('Maslow Settings', 'motorOffsetY'))
+            +" F" + str(self.data.config.get('Maslow Settings', 'sledWidth'))
+            +" R" + str(self.data.config.get('Maslow Settings', 'sledHeight'))
+            +" H" + str(self.data.config.get('Maslow Settings', 'sledCG'))
+            +" Y" + str(kinematicsType)
+            +" Z" + str(self.data.config.get('Advanced Settings', 'rotationRadius'))
+            + " "
+        )
+        
+        self.data.gcode_queue.put(cmdString)
+        
+        
     '''
     
     Update Functions
@@ -611,7 +611,7 @@ class GroundControlApp(App):
         
     
     def setErrorOnScreen(self, message):
-        
+        print message
         try:
             startpt = message.find(':')+1 
             endpt = message.find(',', startpt)

--- a/main.py
+++ b/main.py
@@ -607,11 +607,9 @@ class GroundControlApp(App):
         except:
             print "One Machine Position Report Command Misread"
             return
-        
-        
     
     def setErrorOnScreen(self, message):
-        print message
+        
         try:
             startpt = message.find(':')+1 
             endpt = message.find(',', startpt)


### PR DESCRIPTION
We were seeing issues with the kinematics being unable to load the machine's position.

The issue was that if the machine tried to load it's position from memory before it had been told the specs for the motors it would load an incorrect position, then save incorrect chain lengths to memory. The next time the position was loaded from memory it would be wrong and the machine would try to compute a new position from the incorrect chain lengths and fail

This makes sure that the machine will always have the motor specs BEFORE trying to load the position 