### PR TITLE
switch to is_mouse_scrolling

### DIFF
--- a/UIElements/modernMenu.py
+++ b/UIElements/modernMenu.py
@@ -39,7 +39,6 @@ class ModernMenuLabel(ButtonBehavior, Label):
         
         self.parent.dismiss()
 
-
 class ModernMenu(Widget):
     radius = NumericProperty(50)
     circle_width = NumericProperty(5)
@@ -135,7 +134,7 @@ class MenuSpawner(Widget):
 
     def on_touch_down(self, touch, *args):
         
-        if touch.button == 'scrolldown' or touch.button == 'scrollup':
+        if touch.is_mouse_scrolling:
             #Ignore scroll button
             pass
         else:


### PR DESCRIPTION
Checking for the buttons by name caused issues on touch screen which is probably why the is_mouse_scrolling macro exists 😀 