### PR TITLE
Fix Duplicate Push of Settings; Kludge to Overcome First Cmd Issue

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -90,6 +90,7 @@ class SerialPortThread(MakesmithInitFuncs):
             #print "port open?:"
             #print self.serialInstance.isOpen()
             self.lastMessageTime = time.time()
+            self.data.gcode_queue.put(' ') # send a blank line on startup
             self.data.connectionStatus = 1
             
             self._getFirmwareVersion()

--- a/main.py
+++ b/main.py
@@ -352,8 +352,6 @@ class GroundControlApp(App):
         self.data.bind(connectionStatus = self.push_settings_to_machine)
         self.data.pushSettings = self.push_settings_to_machine
         
-        self.push_settings_to_machine()
-        
         return interface
         
     def build_config(self, config):

--- a/main.py
+++ b/main.py
@@ -438,6 +438,8 @@ class GroundControlApp(App):
         
         #Push motor configuration settings to machine
         
+        if self.data.connectionStatus != 1:
+            return # only run on connection true
         
         if int(self.data.config.get('Advanced Settings', 'enablePosPIDValues')) == 1:
             KpPos = float(self.data.config.get('Advanced Settings', 'KpPos'))


### PR DESCRIPTION
Bind will cause the machine data to be sent, so there is no need to force an additional call on startup.

Similarly, bind will get called on both changes in connection status, so only push setting when connection is up.

Finally, hacked in a blank line into the queue upon serial connection to deal with #404.  There may be better solutions.

Fixes #403 
Fixes #402