### PR TITLE
Fix Popup Numeric Display (clean)

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -345,8 +345,8 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
         '''
         try:
-            float(self.popupContent.textInput.text)
-            self.targetWidget.text = self.popupContent.textInput.text
+            tempfloat = float(self.popupContent.textInput.text)
+            self.targetWidget.text = str(tempfloat)  # Update displayed text using standard numeric format
         except:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -74,8 +74,8 @@ class ZAxisPopupContent(GridLayout):
         
         '''
         try:
-            float(self.popupContent.textInput.text)
-            self.distBtn.text = self.popupContent.textInput.text
+            tempfloat = float(self.popupContent.textInput.text)
+            self.distBtn.text = str(tempfloat)  # Update displayed text using standard numeric format
         except:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()


### PR DESCRIPTION
Fix the number displayed after closing a numeric input popup.
Currently, the number displayed is the text version (string) of what was entered.
For the fix, convert the entered sting to a float (which was already being done to determine whether the entry was a valid number), then convert the float back to a string to be displayed.

Examples:
User Entry, Before Fix, After Fix
"000", "000", "0.0"
".1", ".1", "0.1"
"1.000", "1.000", "1.0"

(This was pull request #412, now submitted as clean update to original master with only one commit.)