### PR TITLE
Update Hold button and stop sending Gcode on pause from Maslow

### DIFF
--- a/main.py
+++ b/main.py
@@ -535,6 +535,9 @@ class GroundControlApp(App):
                     print message
                     measuredDist = float(message[9:len(message)-3])
                     self.data.measureRequest(measuredDist)
+            elif message[0:13] == "Maslow Paused":
+                self.data.uploadFlag = 0
+                self.writeToTextConsole(message)
             elif message[0:8] == "Message:":
                 self.previousUploadStatus = self.data.uploadFlag 
                 self.data.uploadFlag = 0


### PR DESCRIPTION
When Maslow sends "Maslow Paused", set uploadFlag to 0.  This updates the "Hold" button to say "Continue" and stops sending Gcode commands.

While this might not be strictly necessary right now since the "Message:" handler also sets uploadFlag to 0, it could be helpful in the future if/when there are other things that might pause Maslow.  For example, I'm working on Tool Change handling which pauses Maslow while the user changes the tool.  If I use a version of Ground Control that doesn't include a pop-up to prompt the user (but does include this change), the button saying "Continue" instead of "Hold" is a visual indication that Maslow is paused, so the user can look to the text console to see why.  Also, when the user wants to continue, clicking the "Continue" button (once) will un-pause Maslow.  If the button isn't updated, the user has to click it twice: once to change it from "Hold" to "Continue", and again to have Ground Control send the command to un-pause Maslow. 