### PR TITLE
Enable Esc key and fix issue 400

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -85,10 +85,13 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         if keycode[1] == self.data.config.get('Ground Control Settings', 'zoomIn'):
             mat = Matrix().scale(1-scaleFactor, 1-scaleFactor, 1)
             self.scatterInstance.apply_transform(mat, anchor)
+            return True # we handled this key - don't pass to other callbacks
         elif keycode[1] == self.data.config.get('Ground Control Settings', 'zoomOut'):
             mat = Matrix().scale(1+scaleFactor, 1+scaleFactor, 1)
             self.scatterInstance.apply_transform(mat, anchor)
-        return True
+            return True # we handled this key - don't pass to other callbacks
+        else:
+            return False # we didn't handle this key - let next callback handle it
 
     def isClose(self, a, b):
         return abs(a-b) <= self.data.tolerance

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ Kivy Imports
 '''
 from kivy.config                import Config
 Config.set('input', 'mouse', 'mouse,disable_multitouch')
+Config.set('kivy', 'exit_on_escape', '0')
 from kivy.app                   import App
 from kivy.uix.gridlayout        import GridLayout
 from kivy.uix.floatlayout       import FloatLayout
@@ -426,13 +427,6 @@ class GroundControlApp(App):
             if (key == "truncate") or (key == "digits"):
                 self.frontpage.gcodecanvas.reloadGcode()
                 
-            
-
-    def close_settings(self, settings):
-        """
-        Close settings panel
-        """
-        super(GroundControlApp, self).close_settings(settings)
     
     def push_settings_to_machine(self, *args):
         


### PR DESCRIPTION
Enable use of Esc key to navigate back through menus by letting unhandled keys in gcodeCanvas.py be passed to the next callback.  This behavior was broken in pull request #408.  This change also allows use of the F1 key to enter and exit the settings menu.

Now the Esc key causes Ground Control to crash, per issue #400, when pressed at the main screen or in the settings menu.  The same crash is caused by the F1 key when exiting the settings menu.  The issue is caused by the close_settings() handler in main.py.  The error is "TypeError: close_settings() takes exactly 2 arguments (1 given)"  Since close_settings() in main.py doesn't do anything besides call the super version of itself, deleting it solves the problem with no loss of functionality.

Finally, the Esc key will quit Ground Control if pressed at the main screen.  We solve this by setting the kivy exit_on_escape config token to 0 in main.py.