### PR TITLE
Allow windowed mode

### DIFF
--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -29,7 +29,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
                     'along with the Maslow Control Software. If not, see <http://www.gnu.org/licenses/>.'
                 
         content = ScrollableTextPopup(cancel = self.dismiss_popup, text = popupText, markup = True)
-        self._popup = Popup(title="About GroundControl", content=content, size_hint=(0.5, 0.5))
+        self._popup = Popup(title="About GroundControl", content=content, size=(520,400), size_hint=(None, None))
         self._popup.open()
     
     def dismiss_popup(self):

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -44,7 +44,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         
         self.drawWorkspace()
 
-        if self.data.config.getint('Ground Control Settings', 'centerCanvasOnResize'):
+        if self.data.config.getboolean('Ground Control Settings', 'centerCanvasOnResize'):
             Window.bind(on_resize = self.centerCanvas)
 
         self.data.bind(gcode = self.updateGcode)

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -43,18 +43,18 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         self.targetIndicator.color = (1,0,0)
         
         self.drawWorkspace()
-            
-        Window.bind(on_resize = self.centerCanvas)
+
+        if self.data.config.getint('Ground Control Settings', 'centerCanvasOnResize'):
+            Window.bind(on_resize = self.centerCanvas)
 
         self.data.bind(gcode = self.updateGcode)
         self.data.bind(gcodeShift = self.reloadGcode)
-        self.data.bind(gcodeFile = self.reloadGcode)
+        self.data.bind(gcodeFile = self.centerCanvasAndReloadGcode)
         
         global_variables._keyboard = Window.request_keyboard(self._keyboard_closed, self)
         global_variables._keyboard.bind(on_key_down=self._on_keyboard_down)
         
-        self.centerCanvas()
-        self.reloadGcode()
+        self.centerCanvasAndReloadGcode()
     
     def addPoint(self, x, y):
         '''
@@ -93,7 +93,11 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
 
     def isClose(self, a, b):
         return abs(a-b) <= self.data.tolerance
-    
+
+    def centerCanvasAndReloadGcode(self, *args):
+        self.centerCanvas()
+        self.reloadGcode()
+        
     def reloadGcode(self, *args):
         '''
         

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -53,6 +53,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         global_variables._keyboard = Window.request_keyboard(self._keyboard_closed, self)
         global_variables._keyboard.bind(on_key_down=self._on_keyboard_down)
         
+        self.centerCanvas()
         self.reloadGcode()
     
     def addPoint(self, x, y):

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -11,8 +11,9 @@
 <ScreenControls>
     BoxLayout:
         orientation: 'horizontal'
-        pos: (0, root.height - .05*root.height)
-        size_hint: (.6,.05)
+        pos: (0, root.height - 60)
+        size_hint: (.5,None)
+        height: dp(60)
         
         Button: 
             text: "Actions"
@@ -526,7 +527,8 @@
             text: root.text
             
         BoxLayout:
-            #size_hint_y: 1
+            size_hint_y: None
+            height: dp(60)
             Button:
                 text: "Continue"
                 on_release: root.continueOn()
@@ -542,7 +544,7 @@
             
         BoxLayout:
             size_hint_y: None
-            height: dp(30)
+            height: dp(60)
             Button:
                 text: "Close"
                 on_release: root.cancel()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,8 @@ Kivy Imports
 '''
 from kivy.config                import Config
 Config.set('input', 'mouse', 'mouse,disable_multitouch')
+Config.set('graphics', 'minimum_width', '620')
+Config.set('graphics', 'minimum_height', '440')
 from kivy.app                   import App
 from kivy.uix.gridlayout        import GridLayout
 from kivy.uix.floatlayout       import FloatLayout
@@ -280,6 +282,13 @@ class GroundControlApp(App):
     gcsettings = '''
     [
         {
+            "type": "bool",
+            "title": "Center Canvas on Window Resize",
+            "desc": "When resizing the window, automatically reset the Gcode canvas to be centered and zoomed out. Program must be restarted to take effect.",
+            "section": "Ground Control Settings",
+            "key": "centerCanvasOnResize"
+        },
+        {
             "type": "string",
             "title": "Zoom In",
             "desc": "Pressing this key will zoom in. Note combinations of keys like \'shift\' + \'=\' may not work as expected. Program must be restarted to take effect.",
@@ -391,9 +400,10 @@ class GroundControlApp(App):
                                                  'KiV'                : 1,
                                                  'KdV'                : 0})
         
-        config.setdefaults('Ground Control Settings', {'zoomIn': "pageup",
-                                                 'validExtensions':".nc, .ngc, .text, .gcode",
-                                                 'zoomOut': "pagedown"})
+        config.setdefaults('Ground Control Settings', {'centerCanvasOnResize': 0,
+                                                 'zoomIn': "pageup",
+                                                 'zoomOut': "pagedown",
+                                                 'validExtensions': ".nc, .ngc, .text, .gcode"})
 
     def build_settings(self, settings):
         """
@@ -546,7 +556,7 @@ class GroundControlApp(App):
                     pass                                                            #there wasn't a popup to close
                 content = NotificationPopup(continueOn = self.dismiss_popup_continue, text = message[9:])
                 self._popup = Popup(title="Notification: ", content=content,
-                            auto_dismiss=False, size_hint=(0.35, 0.35))
+                            auto_dismiss=False, size=(360,240), size_hint=(None, None))
                 self._popup.open()
                 if global_variables._keyboard:
                     global_variables._keyboard.bind(on_key_down=self.keydown_popup)

--- a/main.py
+++ b/main.py
@@ -305,7 +305,6 @@ class GroundControlApp(App):
     '''
     
     def build(self):
-        Window.maximize()
         
         interface       =  FloatLayout()
         self.data       =  Data()


### PR DESCRIPTION
Under the settings for kivy, there is an option for Fullscreen, which allows the user to choose windowed or fullscreen mode.  But Ground Control forces fullscreen mode regardless of this setting by calling window.maximize() in the build() function of main.py.  This change removes window.maximize() to allow the user to choose windowed or fullscreen mode.

A side effect of this change is that the Gcode canvas is not centered in the window.  This is because the call to window.maximize() triggered the on_resize() callback.  Now that the window.maximize() call is removed, the callback does not occur at initialization.  To fix this, a call to self.centerCanvas() is added to the initialize() function of gcodeCanvas.py.