### PR TITLE
Add a switch to step 7 to enable z-axis

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -32,6 +32,11 @@ class MeasureMachinePopup(GridLayout):
         if self.carousel.index == 4:
             #review calculations
             self.updateReviewValuesText()
+        if self.carousel.index == 7:
+            if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
+                self.zAxisActiveSwitch.active = True
+            else:
+                self.zAxisActiveSwitch.active = False
         if self.carousel.index == 8:
             #Cut test shape
             self.goFwdBtn.disabled = False
@@ -137,7 +142,16 @@ class MeasureMachinePopup(GridLayout):
     def calibrateChainLengths(self):
         print "calibrating"
         self.data.gcode_queue.put("B02 ")
+    
+    def enableZaxis(self, *args):
+        '''
         
+        Triggered when the switch to enable the z-axis is touched
+        
+        '''
+        self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
+        self.data.config.write()
+    
     def enterTestPaternValues(self):
         
         dif = 0

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -684,6 +684,7 @@
     vertMeasure:vertMeasure
     unitsBtn:unitsBtn
     enterValues:enterValues
+    zAxisActiveSwitch:zAxisActiveSwitch
     
     cols: 1
     size: root.size
@@ -909,7 +910,7 @@
                 cols: 1
                 size_hint_x: leftCol
                 Label:
-                    text: "Next, we are going to define the home position for the z-axis\n\nIf you have an automatic z-axis installed use the buttons to adjust the z-axis until the router bit\nbarely touches the surface of the wood. Then press Define Zero\n\nIf you do not have the z-axis installed, adjust your router until the router bit just barely\ntouches the surface of the wood, then press Define Zero"
+                    text: "Next, we are going to define the home position for the z-axis\n\nIf you have an automatic z-axis installed use the buttons to enable it and adjust the z-axis until the router bit\nbarely touches the surface of the wood. Then press Define Zero\n\nIf you do not have the z-axis installed, adjust your router until the router bit just barely\ntouches the surface of the wood, then press Define Zero"
                     size_hint_x: leftCol
                 GridLayout:
                     cols: 2
@@ -919,6 +920,13 @@
                 cols: 1
                 size_hint_x: rightCol
                 Label:
+                GridLayout:
+                    cols: 2
+                    Label:
+                        text: 'Enable\nAutomatic Z-Aixs:'
+                    Switch:
+                        on_active: root.enableZaxis()
+                        id: zAxisActiveSwitch
                 Button:
                     text: 'Raise Z-Axis 1mm'
                     on_release: root.moveZ(1)


### PR DESCRIPTION
In step 7 of the calibration process it was unclear that the z-axis needed to be inabled in settings, and dificult to do so.

This PR updates the text to make it  more clear that it needs to be enabled, and adds a swtich to let you enable it right from step 7.

A fix for issue #407 

![image](https://user-images.githubusercontent.com/9359447/30444974-7fed2516-9939-11e7-9b69-1597c9b8cd9c.png)
