### PR TITLE
Left justify xyz labels (issue #393)

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -46,16 +46,18 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.data = data
     
     def buildReadoutString(self, value):
+        '''
+        
+        Generate the string for the the digital position readout
+        
+        '''
+        
         targetStringLength = 8
         string = '%.2f'%(value)
         
         numberOfSpacesToPad = int(1.5*(targetStringLength - len(string)))
-        print string + ": " + str(numberOfSpacesToPad)
-        
         
         string = ' '*numberOfSpacesToPad + string
-        
-        print string + "|"
         
         return string
     

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -45,10 +45,24 @@ class FrontPage(Screen, MakesmithInitFuncs):
         super(FrontPage, self).__init__(**kwargs)
         self.data = data
     
+    def buildReadoutString(self, value):
+        targetStringLength = 8
+        string = '%.2f'%(value)
+        
+        numberOfSpacesToPad = int(1.5*(targetStringLength - len(string)))
+        print string + ": " + str(numberOfSpacesToPad)
+        
+        
+        string = ' '*numberOfSpacesToPad + string
+        
+        print string + "|"
+        
+        return string
+    
     def setPosReadout(self, xPos, yPos, zPos):
-        self.xReadoutPos    = "X: " + str(xPos)
-        self.yReadoutPos    = "Y: " + str(yPos)
-        self.zReadoutPos    = "Z: " + str(zPos)
+        self.xReadoutPos    = self.buildReadoutString(xPos)
+        self.yReadoutPos    = self.buildReadoutString(yPos)
+        self.zReadoutPos    = self.buildReadoutString(zPos)
         self.numericalPosX  = xPos
         self.numericalPosY  = yPos
     

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -181,11 +181,17 @@
             height: dp(70)
             #disabled: not app.data.connectionStatus
             GridLayout:
-                cols: 1
+                cols: 2
+                Label:
+                    text: 'X :'
                 Label:
                     text: root.xReadoutPos
                 Label:
+                    text: 'Y : '
+                Label:
                     text: root.yReadoutPos
+                Label:
+                    text: 'Z : '
                 Label:
                     text: root.zReadoutPos
             GridLayout:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -183,15 +183,15 @@
             GridLayout:
                 cols: 2
                 Label:
-                    text: 'X :'
+                    text: '                   X :'
                 Label:
                     text: root.xReadoutPos
                 Label:
-                    text: 'Y : '
+                    text: '                   Y : '
                 Label:
                     text: root.yReadoutPos
                 Label:
-                    text: 'Z : '
+                    text: '                   Z : '
                 Label:
                     text: root.zReadoutPos
             GridLayout:


### PR DESCRIPTION
A fix for issue #393 .

It was noted that the text of the x y and z position indicators moved around a lot and resized with the length of the number being displayed.

This PR tries to fix that issue by splitting the string into two labels one for the 'X: ' and one for the number, and by truncating the number to a set number of decimals, then padding back with spaces to get a fixed length string.

The result looks like this:

![image](https://user-images.githubusercontent.com/9359447/30495584-727576ae-9a01-11e7-8035-de49631c0465.png)
