### PR TITLE
Make gc check that version numbers match

### DIFF
--- a/main.py
+++ b/main.py
@@ -568,6 +568,12 @@ class GroundControlApp(App):
             elif message[0:8] == "Firmware":
                 self.data.logger.writeToLog("Ground Control Version " + str(self.data.version) + "\n")
                 self.writeToTextConsole("Ground Control " + str(self.data.version) + "\r\n" + message + "\r\n")
+                
+                #Check that version numbers match
+                if float(message[-7:]) < float(self.data.version):
+                    self.data.message_queue.put("Message: Warning, our firmware is out of date and may not work correctly with this version of Ground Control")
+                if float(message[-7:]) > float(self.data.version):
+                    self.data.message_queue.put("Message: Warning, your version of Ground Control is out of date and may not work with this firmware version")
             elif message == "ok\r\n":
                 pass #displaying all the 'ok' messages clutters up the display
             else:

--- a/main.py
+++ b/main.py
@@ -571,9 +571,9 @@ class GroundControlApp(App):
                 
                 #Check that version numbers match
                 if float(message[-7:]) < float(self.data.version):
-                    self.data.message_queue.put("Message: Warning, our firmware is out of date and may not work correctly with this version of Ground Control")
+                    self.data.message_queue.put("Message: Warning, your firmware is out of date and may not work correctly with this version of Ground Control\n\n" + "Ground Control Version " + str(self.data.version) + "\r\n" + message)
                 if float(message[-7:]) > float(self.data.version):
-                    self.data.message_queue.put("Message: Warning, your version of Ground Control is out of date and may not work with this firmware version")
+                    self.data.message_queue.put("Message: Warning, your version of Ground Control is out of date and may not work with this firmware version\n\n" + "Ground Control Version " + str(self.data.version) + "\r\n" + message)
             elif message == "ok\r\n":
                 pass #displaying all the 'ok' messages clutters up the display
             else:


### PR DESCRIPTION
Ground Control now checks that the GC version number matches the Firmware version number to keep them in sync. That way when we make changes which affect both we won't have a lot of issues

![image](https://user-images.githubusercontent.com/9359447/30980330-8fc34022-a435-11e7-9f53-7822cc626938.png)
