### PR TITLE
Renames the z-in and z-out buttons in the popup

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -14,8 +14,8 @@
         pos: (0, root.height - 60)
         size_hint: (.5,None)
         height: dp(60)
-        
-        Button: 
+
+        Button:
             text: "Actions"
             on_press: root.show_actions()
         Button:
@@ -27,11 +27,11 @@
     scatterInstance:scatterInstance
     positionIndicator:positionIndicator
     targetIndicator:targetIndicator
-    
+
     ScatterPlane:
         do_rotation: False
         id: scatterInstance
-        Label: 
+        Label:
             id: scatterObject
             text: ""
         PositionIndicator:
@@ -49,7 +49,7 @@
                 dict(text='[color=3333ff]Move Here[/color]', markup = True, index=1, callback=root.updateGcode),
                 dict(text='Position Text Placeholder' , markup = True, index=2, callback=root.doNothing),
                 dict(text='[color=3333ff]Mark Here[/color]', markup = True, index=3, callback=root.updateGcode)])
-    
+
 <FrontPage>:
     textconsole:textconsole
     moveDistInput:moveDistInput
@@ -57,8 +57,8 @@
     gcodecanvas:gcodecanvas
     screenControls:screenControls
     holdBtn:holdBtn
-    
-    
+
+
     GcodeCanvas:
         id: gcodecanvas
     BoxLayout:
@@ -137,7 +137,7 @@
             Button:
                 text: 'Define\nHome'
                 on_release: root.moveOrigin()
-        
+
         GridLayout:
             cols: 3
             size_hint: None, None
@@ -215,7 +215,7 @@
             size: dp(300), dp(200)
             text: root.consoleText
             size_hint: None, None
-    
+
     ScreenControls:
         id: screenControls
         size_hint: (1, 1)
@@ -241,7 +241,7 @@
         disabled: False
         on_press: app.frontpage.gcodecanvas.centerCanvas()
         on_release: root.resetView()
-                
+
 <RunMenu>:
     GridLayout:
         cols: 1
@@ -284,11 +284,11 @@
             id: ports
             text: "Ports"
             values: root.COMports
-            on_text: root.setPort(ports.text)   
+            on_text: root.setPort(ports.text)
         Button:
             text: 'Update List'
             on_press: root.updatePorts()
-                
+
 <Diagnostics>:
     GridLayout:
         rows: 2
@@ -367,7 +367,7 @@
             Button:
                 disabled: True
                 text: '5'
-            
+
             Label:
                 text: "Y:"
             Button:
@@ -403,7 +403,7 @@
             Button:
                 disabled: True
                 text: '5'
-            
+
             Label:
                 text: "Z:"
             Button:
@@ -439,20 +439,20 @@
             Button:
                 disabled: True
                 text: '5'
-                
+
 <OtherFeatures>:
     connectmenu:connectmenu
     viewmenu:viewmenu
     diagnostics:diagnostics
     runmenu:runmenu
-    
+
     BoxLayout:
         orientation: 'vertical'
         BoxLayout:
             orientation: 'horizontal'
             padding:2
             spacing:0
-            
+
             ViewMenu:
                 id: viewmenu
             RunMenu:
@@ -463,7 +463,7 @@
             orientation: 'vertical'
             padding:2
             spacing:0
-            
+
             Diagnostics:
                 id: diagnostics
             Button:
@@ -472,9 +472,9 @@
                 on_release: root.close()
 
 <SoftwareSettings>:
-    
+
 <PositionIndicator>:
-    size: 50, 50 
+    size: 50, 50
     canvas:
         Color:
             rgb: root.color
@@ -491,7 +491,7 @@
             points: (self.x-self.width/2, self.y-self.height/2, self.width/2+self.x, self.height/2+self.y)
         Line:
             points: (self.x-self.width/2, self.height/2+self.y, self.width/2+self.x, self.y-self.height/2)
-    
+
 <LoadDialog>:
     BoxLayout:
         size: root.size
@@ -528,10 +528,10 @@
         size: root.size
         pos: root.pos
         orientation: "vertical"
-        
+
         ScrollableLabel:
             text: root.text
-            
+
         BoxLayout:
             size_hint_y: None
             height: dp(60)
@@ -544,10 +544,10 @@
         size: root.size
         pos: root.pos
         orientation: "vertical"
-        
+
         ScrollableLabel:
             text: root.text
-            
+
         BoxLayout:
             size_hint_y: None
             height: dp(60)
@@ -560,10 +560,10 @@
         size: root.size
         pos: root.pos
         orientation: "vertical"
-        
+
         ScrollableLabel:
             text: root.text
-            
+
         BoxLayout:
             size_hint_y: None
             height: dp(30)
@@ -669,7 +669,7 @@
             on_release: root.units()
             id: unitsBtn
         Button:
-            text: "Z-In"
+            text: "Lower"
             on_release: root.zIn()
         Button:
             text: "Done"
@@ -678,7 +678,7 @@
             text: "Define Zero"
             on_release: root.zero()
         Button:
-            text: "Z-Out"
+            text: "Raise"
             on_release: root.zOut()
 
 <MeasureMachinePopup>:
@@ -693,7 +693,7 @@
     unitsBtn:unitsBtn
     enterValues:enterValues
     zAxisActiveSwitch:zAxisActiveSwitch
-    
+
     cols: 1
     size: root.size
     pos: root.pos
@@ -1010,11 +1010,11 @@
 
 <CalibrateLengthsPopup>:
     carousel:carousel
-    
+
     cols: 1
     size: root.size
     pos: root.pos
-    
+
     Carousel:
         id: carousel
         direction: "right"


### PR DESCRIPTION
Fixes #432

This renames z-in to lower and z-out to raise
to improve readability of the interface on the
zaxis popup from the front page.