### PR TITLE
Gobble space runs

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -114,6 +114,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             rawfilters = filterfile.read()
             filtersparsed = re.sub(r'\(([^)]*)\)','',rawfilters) #removes mach3 style gcode comments
             filtersparsed = re.sub(r';([^\n]*)\n','',filtersparsed) #removes standard ; initiated gcode comments
+            filtersparsed = re.sub(r'  +',' ',filtersparsed) #condense space runs
 
             if self.data.config.getint('Advanced Settings','truncate'):
                 digits = self.data.config.get('Advanced Settings','digits')


### PR DESCRIPTION
Some gcode creation programs sprinkle space runs within the gcode lines. This will condense all runs to a single space.