### PR TITLE
Fix osx notification size

### DIFF
--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -5,6 +5,7 @@ from kivy.uix.popup                              import    Popup
 from UIElements.measureMachinePopup              import    MeasureMachinePopup
 from UIElements.calibrateLengthsPopup            import    CalibrateLengthsPopup
 from Simulation.simulationCanvas                 import SimulationCanvas
+import sys
 
 class Diagnostics(FloatLayout, MakesmithInitFuncs):
     
@@ -29,7 +30,10 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
                     'along with the Maslow Control Software. If not, see <http://www.gnu.org/licenses/>.'
                 
         content = ScrollableTextPopup(cancel = self.dismiss_popup, text = popupText, markup = True)
-        self._popup = Popup(title="About GroundControl", content=content, size=(520,400), size_hint=(None, None))
+        if sys.platform.startswith('darwin'):
+            self._popup = Popup(title="About GroundControl", content=content, size=(520,400), size_hint=(.6, .6))
+        else:
+            self._popup = Popup(title="About GroundControl", content=content, size=(520,400), size_hint=(None, None))
         self._popup.open()
     
     def dismiss_popup(self):

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -114,6 +114,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             rawfilters = filterfile.read()
             filtersparsed = re.sub(r'\(([^)]*)\)','',rawfilters) #removes mach3 style gcode comments
             filtersparsed = re.sub(r';([^\n]*)\n','',filtersparsed) #removes standard ; initiated gcode comments
+            filtersparsed = re.sub(r'  +',' ',filtersparsed) #condense space runs
 
             if self.data.config.getint('Advanced Settings','truncate'):
                 digits = self.data.config.get('Advanced Settings','digits')

--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ from kivy.clock                 import Clock
 from kivy.uix.popup             import Popup
 import math
 import global_variables
+import sys
 
 
 '''
@@ -559,7 +560,11 @@ class GroundControlApp(App):
                 except:
                     pass                                                            #there wasn't a popup to close
                 content = NotificationPopup(continueOn = self.dismiss_popup_continue, text = message[9:])
-                self._popup = Popup(title="Notification: ", content=content,
+                if sys.platform.startswith('darwin'):
+                    self._popup = Popup(title="Notification: ", content=content,
+                            auto_dismiss=False, size=(360,240), size_hint=(.3, .3))
+                else:
+                    self._popup = Popup(title="Notification: ", content=content,
                             auto_dismiss=False, size=(360,240), size_hint=(None, None))
                 self._popup.open()
                 if global_variables._keyboard:


### PR DESCRIPTION
OSX screen resolution makes popups h- and v-size too to small to read content. Use size_hint to scale popup to the screen size, special case for darwin to avoid affecting other platforms.