### PR TITLE
Add more info to simulation

### DIFF
--- a/Simulation/simulationCanvas.py
+++ b/Simulation/simulationCanvas.py
@@ -289,28 +289,28 @@ class SimulationCanvas(GridLayout):
     def onSliderChange(self, *args):
 
         self.distortedKinematics.motorOffsetY = self.correctKinematics.motorOffsetY + self.motorVerticalError.value
-        #self.motorVerticalErrorLabel.text = "Motor Vertical\nError: " + str(int(self.motorVerticalError.value)) + "mm"
+        self.motorVerticalErrorLabel.text = "Motor Vertical\nError: " + "%.2f" % self.motorVerticalError.value + "mm"
 
         self.distortedKinematics.l = self.correctKinematics.l + self.sledMountSpacingError.value
-        self.sledMountSpacingErrorLabel.text = "Sled Mount\nSpacing Error: " + str(int(self.sledMountSpacingError.value)) + "mm"
+        self.sledMountSpacingErrorLabel.text = "Sled Mount\nSpacing Error: " + "%.2f" % self.sledMountSpacingError.value + "mm"
 
         self.distortedKinematics.D = self.correctKinematics.D + self.motorSpacingError.value
-        self.motorSpacingErrorLabel.text = "Motor Spacing\nError: " + str(int(self.motorSpacingError.value)) + "mm"
+        self.motorSpacingErrorLabel.text = "Motor Spacing\nError: " + "%.2f" % self.motorSpacingError.value + "mm"
 
         self.distortedKinematics.s = self.correctKinematics.s + self.vertBitDist.value
-        self.vertBitDistLabel.text = "Vert Dist To\nBit Error: " + str(int(self.vertBitDist.value)) + "mm"
+        self.vertBitDistLabel.text = "Vert Dist To\nBit Error: " + "%.2f" % self.vertBitDist.value + "mm"
 
         self.distortedKinematics.h3 = self.correctKinematics.h3 + self.vertCGDist.value
-        self.vertCGDistLabel.text = "Vert Dist\nBit to CG Error: " + str(int(self.vertCGDist.value)) + "mm"
+        self.vertCGDistLabel.text = "Vert Dist\nBit to CG Error: " + "%.2f" % self.vertCGDist.value + "mm"
 
         self.distortedKinematics.chain1Offset = int(self.leftChainOffset.value)
-        self.leftChainOffsetLabel.text = "Left Chain\nSlipped Links: " + str(int(self.leftChainOffset.value)) + "links"
+        self.leftChainOffsetLabel.text = "Left Chain\nSlipped Links: " + "%.2f" % self.leftChainOffset.value + "links"
 
         self.distortedKinematics.chain2Offset = int(self.rightChainOffset.value)
-        self.rightChainOffsetLabel.text = "Right Chain\nSlipped Links: " + str(int(self.rightChainOffset.value)) + "links"
+        self.rightChainOffsetLabel.text = "Right Chain\nSlipped Links: " + "%.2f" % self.rightChainOffset.value + "links"
         
         self.distortedKinematics.rotationDiskRadius = self.correctKinematics.rotationDiskRadius + self.rotationRadiusOffset.value
-        self.rotationRadiusLabel.text = "Rotation Radius\nSpacing Error: " + str(int(self.rotationRadiusOffset.value)) + "mm"
+        self.rotationRadiusLabel.text = "Rotation Radius\nSpacing Error: " + "%.2f" % self.rotationRadiusOffset.value + "mm"
         
         #self.machineLabel.text = "distance between sled attachments ideal: "+str(self.correctKinematics.l)+" actual: "+str(self.distortedKinematics.l)+"mm\nvertical distance between sled attachments and bit ideal: "+str(self.correctKinematics.s)+" actual: "+str(self.distortedKinematics.s)+"mm\nvertical distance between sled attachments and CG ideal: "+str(self.correctKinematics.h3+self.correctKinematics.s)+" actual: "+str(self.distortedKinematics.h3+self.distortedKinematics.s)+"mm\ndistance between motors ideal: "+str(self.correctKinematics.D)+" actual: "+str(self.distortedKinematics.D)+"mm"
 

--- a/Simulation/simulationCanvas.py
+++ b/Simulation/simulationCanvas.py
@@ -238,7 +238,42 @@ class SimulationCanvas(GridLayout):
         
         printString = printString + "\n\nThe triangular calibration test is off by " + str(lengthMM - (distortedPoint2[0] - distortedPoint1[0])) + "mm"
         
-        self.machineLabel.text = printString
+        self.machineLabel1.text = printString
+        
+        
+        
+        
+        lengthMM = 800
+        xOffset = 1100 - lengthMM/2
+        yOffset = 500  - lengthMM/2
+        
+        #horizontal measurement 
+        pointPlotted1, distortedPoint1 = self.testPointGenerator.plotPoint(-lengthMM/2, yOffset)
+        pointPlotted2, distortedPoint2 = self.testPointGenerator.plotPoint(lengthMM/2,  yOffset)
+        
+        #vertical measurement
+        pointPlotted3, distortedPoint3 = self.testPointGenerator.plotPoint(xOffset, lengthMM/2)
+        pointPlotted4, distortedPoint4 = self.testPointGenerator.plotPoint(xOffset, -lengthMM/2)
+        
+        printString = "An 800mm square in the top corner on the sheet is distorted\n" + str(lengthMM - (distortedPoint2[0] - distortedPoint1[0])) + "mm horizontally, and " + str(lengthMM - (distortedPoint3[1] - distortedPoint4[1])) + "mm vertically."
+        
+        lengthMM = 800
+        xOffset = 1100 - lengthMM/2
+        yOffset = 500  - lengthMM/2
+        
+        #horizontal measurement 
+        pointPlotted1, distortedPoint1 = self.testPointGenerator.plotPoint(-lengthMM/2, -yOffset)
+        pointPlotted2, distortedPoint2 = self.testPointGenerator.plotPoint(lengthMM/2,  -yOffset)
+        
+        #vertical measurement
+        pointPlotted3, distortedPoint3 = self.testPointGenerator.plotPoint(xOffset, lengthMM/2)
+        pointPlotted4, distortedPoint4 = self.testPointGenerator.plotPoint(xOffset, -lengthMM/2)
+        
+        printString = printString + "\n\nAn 800mm square in the top corner on the sheet is distorted\n" + str(lengthMM - (distortedPoint2[0] - distortedPoint1[0])) + "mm horizontally, and " + str(lengthMM - (distortedPoint3[1] - distortedPoint4[1])) + "mm vertically."
+        
+        
+        self.machineLabel2.text = printString
+        
     
     def setKinematics(self, kinematicsType):
         

--- a/Simulation/simulationCanvas.py
+++ b/Simulation/simulationCanvas.py
@@ -229,7 +229,14 @@ class SimulationCanvas(GridLayout):
         pointPlotted3, distortedPoint3 = self.testPointGenerator.plotPoint(0, lengthMM/2)
         pointPlotted4, distortedPoint4 = self.testPointGenerator.plotPoint(0, -lengthMM/2)
         
-        printString = "An 800mm square centered on the sheet is distorted\n" + str(lengthMM - (distortedPoint3[1] - distortedPoint4[1])) + "mm horizontally, and " + str(lengthMM - (distortedPoint2[0] - distortedPoint1[0])) + "mm vertically."
+        printString = "An 800mm square centered on the sheet is distorted\n" + str(lengthMM - (distortedPoint2[0] - distortedPoint1[0])) + "mm horizontally, and " + str(lengthMM - (distortedPoint3[1] - distortedPoint4[1])) + "mm vertically."
+        
+        lengthMM = 1905/2
+        
+        pointPlotted1, distortedPoint1 = self.testPointGenerator.plotPoint(-lengthMM/2, -400)
+        pointPlotted2, distortedPoint2 = self.testPointGenerator.plotPoint(lengthMM/2,  -400)
+        
+        printString = printString + "\n\nThe triangular calibration test is off by " + str(lengthMM - (distortedPoint2[0] - distortedPoint1[0])) + "mm"
         
         self.machineLabel.text = printString
     

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1181,7 +1181,8 @@
     vertCGDistLabel:vertCGDistLabel
     leftChainOffsetLabel:leftChainOffsetLabel
     rightChainOffsetLabel:rightChainOffsetLabel
-    machineLabel:machineLabel
+    machineLabel1:machineLabel1
+    machineLabel2:machineLabel2
     gridSize:gridSize
     gridSizeLabel:gridSizeLabel
     rotationRadiusOffset:rotationRadiusOffset
@@ -1192,11 +1193,17 @@
     Label:
         text: "This simulation is designed to help us understand how the math behind Maslow is affected by errors in the computed machine dimensions\nTry adding error to any measurement, then press Recompute to see the affect\nThe path computed with the correct values is shown in green, the path with error added is shown in red"
         size_hint_y:.1
-    Label:
-        text: "Machine Specs will appear here"
-        id: machineLabel
-        font_size: 10
-        size_hint_y:.1
+    GridLayout:
+        cols: 2
+        size_hint_y: .1
+        Label:
+            text: "Not yet computed"
+            id: machineLabel1
+            font_size: 10
+        Label:
+            text: "Not yet computed"
+            id: machineLabel2
+            font_size: 10
     GridLayout:
         cols: 2
         size_hint_y: .9


### PR DESCRIPTION
Adds:

- Readout for squares in the upper and lower corners
- Readout for how close the triangular calibration system line is (to test how that system will perform)
- Two decimals of readout for the slider positions to make it more clear that they are floating point numbers, not just integer ticks

Thanks for @davidelang for the suggestion