### PR TITLE
Move sled to center of work area after finishing measure out chains step

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -204,6 +204,11 @@ class MeasureMachinePopup(GridLayout):
         '''
         self.reviewNumbers.text = "Let's review the measurements we've made so far to make sure they look correct\n\nMotor Spacing: " + str(self.data.config.get('Maslow Settings', 'motorSpacingX')) + "mm\nSled Mount Spacing: " + str(self.data.config.get('Maslow Settings', 'sledWidth')) + "mm\nVertical Offset: " + str(self.data.config.get('Maslow Settings', 'motorOffsetY')) + "mm\n\nYou can go back and re-do any of these numbers if you would like"
     
+    def finishChainCalibration(self, *args):
+        #adjust chain lengths to put the sled in the center
+        self.data.gcode_queue.put("B15 ")
+        self.carousel.load_next()
+    
     def setKinematicsType(self, *args):
         '''
         

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -902,7 +902,7 @@
                 cols: 1
                 size_hint_x: leftCol
                 Label:
-                    text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
+                    text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
                     size_hint_x: leftCol
                 GridLayout:
                     cols: 2
@@ -922,7 +922,7 @@
                     on_release: root.stopCut()
                 Button:
                     text: 'Next'
-                    on_release: carousel.load_next()
+                    on_release: root.finishChainCalibration()
                 Label:
         #set z-axis depth
         GridLayout:


### PR DESCRIPTION
Send a B15 command to move the sled to the center after the chain length step of the calibration process. A part of firmware issue [#323](https://github.com/MaslowCNC/Firmware/issues/323)