### PR TITLE
Added zAxisAuto configuration option for spindle automation

### DIFF
--- a/main.py
+++ b/main.py
@@ -119,6 +119,13 @@ class GroundControlApp(App):
             "key": "zAxis"
         },
         {
+            "type": "bool",
+            "title": "Spindle Automation",
+            "desc": "Should the spindle start and stop automatically based on gcode? Leave off for default stepper control.",
+            "section": "Maslow Settings",
+            "key": "zAxisAuto"
+        },
+        {
             "type": "string",
             "title": "Z-Axis Pitch",
             "desc": "The number of mm moved per rotation of the z-axis",
@@ -378,7 +385,8 @@ class GroundControlApp(App):
         Set the default values for the config sections.
         """
         config.setdefaults('Maslow Settings', {'COMport'         : '',
-                                                 'zAxis'         : 0, 
+                                                 'zAxis'         : 0,
+                                                 'zAxisAuto'     : 0,
                                                  'zDistPerRot'   : 3.17, 
                                                  'bedWidth'      : 2438.4, 
                                                  'bedHeight'     : 1219.2, 
@@ -490,6 +498,7 @@ class GroundControlApp(App):
             +" V" + str(KpV)
             +" W" + str(KiV)
             +" X" + str(KdV)
+            +" Y" + str(self.data.config.get('Maslow Settings', 'zAxisAuto'))
             + " "
         )
         


### PR DESCRIPTION
Add an option to the Settings panel which enables automated power control (M codes) to be handled by the AUX1 high signal.  Accompanying firmware change is at https://github.com/MaslowCNC/Firmware/pull/328 
