### PR TITLE
Support touchscreen number entry for calibration. Fixes #443

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -8,6 +8,7 @@ from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   UIElements.touchNumberInput               import   TouchNumberInput
 from   kivy.uix.popup                            import   Popup
+import global_variables
 
 class MeasureMachinePopup(GridLayout):
     done   = ObjectProperty(None)
@@ -198,7 +199,63 @@ class MeasureMachinePopup(GridLayout):
         Clock.schedule_once(self.updateReviewValuesText, .4)
         
         self.carousel.load_next()
-    
+
+    def textInputPopup(self, target):
+        self.targetWidget = target
+
+        self.popupContent = TouchNumberInput(done=self.dismiss_popup)
+        self._popup = Popup(title="Number of links", content=self.popupContent,
+                            size_hint=(0.9, 0.9))
+        self._popup.open()
+        if global_variables._keyboard:
+            global_variables._keyboard.bind(on_key_down=self.keydown_popup)
+            self._popup.bind(on_dismiss=self.ondismiss_popup)
+
+    def dismiss_popup(self):
+        try:
+            tempfloat = float(self.popupContent.textInput.text)
+            self.targetWidget.text = str(tempfloat)  # Update displayed text using standard numeric format
+        except:
+            pass  # If what was entered cannot be converted to a number, leave the value the same
+        self._popup.dismiss()
+
+    def ondismiss_popup(self, event):
+       if global_variables._keyboard:
+           global_variables._keyboard.unbind(on_key_down=self.keydown_popup)
+
+
+    def keydown_popup(self, keyboard, keycode, text, modifiers):
+        if (keycode[1] == '0') or (keycode[1] =='numpad0'):
+            self.popupContent.addText('0')
+        elif (keycode[1] == '1') or (keycode[1] =='numpad1'):
+            self.popupContent.addText('1')
+        elif (keycode[1] == '2') or (keycode[1] =='numpad2'):
+            self.popupContent.addText('2')
+        elif (keycode[1] == '3') or (keycode[1] =='numpad3'):
+            self.popupContent.addText('3')
+        elif (keycode[1] == '4') or (keycode[1] =='numpad4'):
+            self.popupContent.addText('4')
+        elif (keycode[1] == '5') or (keycode[1] =='numpad5'):
+            self.popupContent.addText('5')
+        elif (keycode[1] == '6') or (keycode[1] =='numpad6'):
+            self.popupContent.addText('6')
+        elif (keycode[1] == '7') or (keycode[1] =='numpad7'):
+            self.popupContent.addText('7')
+        elif (keycode[1] == '8') or (keycode[1] =='numpad8'):
+            self.popupContent.addText('8')
+        elif (keycode[1] == '9') or (keycode[1] =='numpad9'):
+            self.popupContent.addText('9')
+        elif (keycode[1] == '.') or (keycode[1] =='numpaddecimal'):
+            self.popupContent.addText('.')
+        elif (keycode[1] == 'backspace'):
+            self.popupContent.textInput.text = self.popupContent.textInput.text[:-1]
+        elif (keycode[1] == 'enter') or (keycode[1] =='numpadenter'):
+            self.popupContent.done()
+        elif (keycode[1] == 'escape'):     # abort entering a number, keep the old number
+            self.popupContent.textInput.text = ''    # clear text so it isn't converted to a number
+            self.popupContent.done()
+        return True     # always swallow keypresses since this is a modal dialog
+
     def countLinks(self):
         print "counting links, dist: "
         
@@ -432,3 +489,4 @@ class MeasureMachinePopup(GridLayout):
         '''
         self.data.gcode_queue.put("G10 Z0 ")
         self.carousel.load_next()
+

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -818,7 +818,7 @@
             GridLayout:
                 cols: 1
                 Label:
-                    text: "Detach the end of the chain from the right sprocket\n\nFeed the free end through the sled mounting brackets and hold it in place with cotter pins\n\nCount the holes between the two pins and enter the number in the box to the right, then press Enter\nWe will refine this measurement later, it is only an initial guess.\n\nSkip this step if you are using a linkage kit"
+                    text: "Detach the end of the chain from the right sprocket\n\nFeed the free end through the sled mounting brackets and hold it in place with cotter pins\n\nCount the holes between the two pins and enter the number in the box to the right, then click Continue\nWe will refine this measurement later, it is only an initial guess.\n\nSkip this step if you are using a linkage kit"
                     size_hint_x: leftCol
                 Image:
                     source: "./Documentation/Calibrate Machine Dimensions/Chain Between Sled Mounts.jpg"
@@ -832,11 +832,13 @@
                 Button:
                     text: 'Retract Left Chain 10mm'
                     on_release: root.retractLeft(10)
-                TextInput:
-                    text: "0"
-                    id: linksTextInput
                 Button:
-                    text: "Enter # of\nLinks"
+                    id: linksTextInput
+                    text: "0"
+                    multiline: False
+                    on_press: root.textInputPopup(self)
+                Button:
+                    text: "Continue"
                     on_release: root.countLinks()
                 Label:
         #Measure to the top of the sheet


### PR DESCRIPTION
This adds the number popup for calibration use, and text clarifies usage.

I think we will want to move this popup to it's own element as it's beginning to be reused in a few places now.