### PR TITLE
Make macro titles configurable

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -76,6 +76,7 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.data.bind(gcodeIndex       = self.onIndexMove)
         self.data.bind(gcodeFile        = self.onGcodeFileChange)
         self.data.bind(uploadFlag       = self.onUploadFlagChange)
+        self.update_macro_titles()
     
     def updateConnectionStatus(self, callback, connected):
         
@@ -401,4 +402,8 @@ class FrontPage(Screen, MakesmithInitFuncs):
         Execute user defined macro
         '''
         self.data.gcode_queue.put(self.data.config.get('Maslow Settings', 'macro' + str(index))) 
+
+    def update_macro_titles(self):
+        self.macro1Btn.text = self.data.config.get('Maslow Settings', 'macro1_title')
+        self.macro2Btn.text = self.data.config.get('Maslow Settings', 'macro2_title')
 

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -57,6 +57,8 @@
     gcodecanvas:gcodecanvas
     screenControls:screenControls
     holdBtn:holdBtn
+    macro1Btn:macro1Btn
+    macro2Btn:macro2Btn
 
 
     GcodeCanvas:
@@ -86,7 +88,8 @@
                     Triangle:
                         points: self.x+self.width/2,self.y+self.width/2,self.x+self.width/2,self.y+self.width/4,self.x+self.width/4,self.y+self.width/2,
             Button:
-                text: 'Macro 1'
+                id: macro1Btn
+                text: "Macro 1"
                 on_press: root.macro(1)
             Button:
                 on_press: root.left()
@@ -102,7 +105,8 @@
                     Triangle:
                         points: self.x+2*self.width/3,self.y+self.height/2,self.x+self.width/3,self.y+self.height/3,self.x+self.width/3,self.y+2*self.height/3,
             Button:
-                text: 'Macro 2'
+                id: macro2Btn
+                text: "Macro 2"
                 on_press: root.macro(2)
             Button:
                 on_press: root.downLeft()

--- a/main.py
+++ b/main.py
@@ -141,10 +141,24 @@ class GroundControlApp(App):
         },
         {
             "type": "string",
+            "title": "Macro 1 Title",
+            "desc": "User defined title for the Macro 1 button",
+            "section": "Maslow Settings",
+            "key": "macro1_title"
+        },
+        {
+            "type": "string",
             "title": "Macro 2",
             "desc": "User defined gcode bound to the Macro 2 button",
             "section": "Maslow Settings",
             "key": "macro2"
+        },
+        {
+            "type": "string",
+            "title": "Macro 2 Title",
+            "desc": "User defined title for the Macro 2 button",
+            "section": "Maslow Settings",
+            "key": "macro2_title"
         }
     ]
     '''
@@ -358,7 +372,6 @@ class GroundControlApp(App):
         self.nonVisibleWidgets.setUpData(self.data)
         self.frontpage.gcodecanvas.initialize()
         
-        
         '''
         Scheduling
         '''
@@ -389,7 +402,9 @@ class GroundControlApp(App):
                                                  'sledCG'        : 79, 
                                                  'openFile'      : " ",
                                                  'macro1'        : "",
-                                                 'macro2'        : ""})
+                                                 'macro1_title'  : "Macro 1",
+                                                 'macro2'        : "",
+                                                 'macro2_title'  : "Macro 2"})
 
         config.setdefaults('Advanced Settings', {'encoderSteps'       : 8148.0,
                                                  'gearTeeth'          : 10, 
@@ -438,6 +453,9 @@ class GroundControlApp(App):
             
             if (key == "bedHeight" or key == "bedWidth"):
                 self.frontpage.gcodecanvas.drawWorkspace()
+
+            if (key == "macro1_title") or (key == "macro2_title"):
+                self.frontpage.update_macro_titles()
 
         if section == "Advanced Settings":
             
@@ -678,8 +696,6 @@ class GroundControlApp(App):
             
         except:
             print "Machine Position Report Command Misread Happened Once"
-        
-        
     
 if __name__ == '__main__':
     GroundControlApp().run()


### PR DESCRIPTION
Allows user to customize "Macro 1" and "Macro 2" strings.
I use these for spindle start/stop myself.