### PR TITLE
Set the chain pitch back to 1/4 inch (6.35mm)

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -175,7 +175,7 @@ class MeasureMachinePopup(GridLayout):
     
     def readMotorSpacing(self, dist):
         
-        dist = dist - 2*6.25                                #subtract off the extra two links
+        dist = dist - 2*6.35                                #subtract off the extra two links
         
         print "Read motor spacing: " + str(dist)
         self.data.config.set('Maslow Settings', 'motorSpacingX', str(dist))
@@ -260,7 +260,7 @@ class MeasureMachinePopup(GridLayout):
         print "counting links, dist: "
         
         try:
-            dist =  float(self.linksTextInput.text)*6.25
+            dist =  float(self.linksTextInput.text)*6.35
         except:
             self.carousel.load_next()
             return


### PR DESCRIPTION
I mistakenly changed the pitch of the chain to 6.25mm instead of the correct value of 6.35mm (thanks to @blurfl for the catch!!) In fixing it I noticed that it is also incorrect in the motor spacing measurement section which could explain the motor spacing measurement inacuracy we've been seeing. Let's keep an eye out for this bug in other places