### PR TITLE
Fix for 470

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -953,7 +953,7 @@
                 GridLayout:
                     cols: 2
                     Label:
-                        text: 'Enable\nAutomatic Z-Aixs:'
+                        text: 'Enable\nAutomatic Z-Axis:'
                     Switch:
                         on_active: root.enableZaxis()
                         id: zAxisActiveSwitch


### PR DESCRIPTION
Fixed typo `Aixs` = `Axis`