### PR TITLE
Create objects for some calibration functionality

### DIFF
--- a/UIElements/calibrateLengthsPopup.py
+++ b/UIElements/calibrateLengthsPopup.py
@@ -8,6 +8,7 @@ from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   kivy.uix.popup                            import   Popup
 from   UIElements.setSprocketsVertical           import   SetSprocketsVertical
+from   UIElements.measureOutChains               import   MeasureOutChains
 
 class CalibrateLengthsPopup(GridLayout):
     done   = ObjectProperty(None)
@@ -20,15 +21,8 @@ class CalibrateLengthsPopup(GridLayout):
         
         '''
         self.data = data
-        self.setSprocketsVertical.data = data
-        self.setSprocketsVertical.carousel = self.carousel
-    
-    def stop(self):
-        self.data.quick_queue.put("!") 
-        with self.data.gcode_queue.mutex:
-            self.data.gcode_queue.queue.clear()
-    
-    def calibrateChainLengths(self):
-        self.data.gcode_queue.put("B02 ")
-        
+        self.setSprocketsVertical.data      =  data
+        self.measureOutChains.data          =  data
+        self.setSprocketsVertical.carousel  =  self.carousel
+        self.measureOutChains.done          =  self.done
     

--- a/UIElements/calibrateLengthsPopup.py
+++ b/UIElements/calibrateLengthsPopup.py
@@ -27,4 +27,5 @@ class CalibrateLengthsPopup(GridLayout):
         
         self.measureOutChains.data          =  data
         self.measureOutChains.carousel      =  self.carousel
+        self.measureOutChains.text          = "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of each chain on the vertical tooth of each sprocket\n as shown in the picture below. Then press Calibrate Chain Lengths\n\nThe correct length of first the left and then the right chain will be measured out\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way\n\nOnce both chains are finished attach the sled, then press Next\n\nPressing Next will move the sled to the center of the work area"
     

--- a/UIElements/calibrateLengthsPopup.py
+++ b/UIElements/calibrateLengthsPopup.py
@@ -21,8 +21,10 @@ class CalibrateLengthsPopup(GridLayout):
         
         '''
         self.data = data
+        
         self.setSprocketsVertical.data      =  data
-        self.measureOutChains.data          =  data
         self.setSprocketsVertical.carousel  =  self.carousel
-        self.measureOutChains.done          =  self.done
+        
+        self.measureOutChains.data          =  data
+        self.measureOutChains.carousel      =  self.carousel
     

--- a/UIElements/calibrateLengthsPopup.py
+++ b/UIElements/calibrateLengthsPopup.py
@@ -7,40 +7,26 @@ from   kivy.uix.gridlayout                       import   GridLayout
 from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   kivy.uix.popup                            import   Popup
+from   UIElements.setSprocketsVertical           import   SetSprocketsVertical
 
 class CalibrateLengthsPopup(GridLayout):
     done   = ObjectProperty(None)
     
-    def LeftCW(self):
-        self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L.5 ")
-        self.data.gcode_queue.put("G90 ")
     
-    def LeftCCW(self):
-        self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L-.5 ")
-        self.data.gcode_queue.put("G90 ")
+    def establishDataConnection(self, data):
+        '''
         
-    def RightCW(self):
-        print "right CW"
-        self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R-.5 ")
-        self.data.gcode_queue.put("G90 ")
-    
-    def RightCCW(self):
-        self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R.5 ")
-        self.data.gcode_queue.put("G90 ")
+        Sets up the data connection between this popup and the shared data object
+        
+        '''
+        self.data = data
+        self.setSprocketsVertical.data = data
+        self.setSprocketsVertical.carousel = self.carousel
     
     def stop(self):
         self.data.quick_queue.put("!") 
         with self.data.gcode_queue.mutex:
             self.data.gcode_queue.queue.clear()
-    
-    def setZero(self):
-        #mark that the sprockets are straight up
-        self.data.gcode_queue.put("B06 L0 R0 ");
-        self.carousel.load_next()
     
     def calibrateChainLengths(self):
         self.data.gcode_queue.put("B02 ")

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -84,7 +84,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         
         '''
         self.popupContent      = MeasureMachinePopup(done=self.dismissMeasureMachinePopup)
-        self.popupContent.data = self.data
+        self.popupContent.establishDataConnection(self.data)
         self._popup = Popup(title="Setup Machine Dimensions", content=self.popupContent,
                             size_hint=(0.85, 0.95), auto_dismiss = False)
         self._popup.open()

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -49,7 +49,9 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         self.data.gcode_queue.put("B06 L0 R0 ");
         
         self.popupContent      = CalibrateLengthsPopup(done=self.dismissMeasureMachinePopup)
-        self.popupContent.data = self.data
+        
+        self.popupContent.establishDataConnection(self.data)
+        
         self._popup = Popup(title="Calibrate Chain Lengths", content=self.popupContent,
                             size_hint=(0.85, 0.95), auto_dismiss = False)
         self._popup.open()

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -22,8 +22,6 @@ class MeasureMachinePopup(GridLayout):
         
         '''
         
-        print "THIS BIT RAN"
-        
         self.data = data
         
         self.setSprocketsVertical.data      =  data

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -31,6 +31,7 @@ class MeasureMachinePopup(GridLayout):
         
         self.measureOutChains.data          =  data
         self.measureOutChains.carousel      =  self.carousel
+        self.measureOutChains.text          =  "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
     
     def backBtn(self, *args):
         '''

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -15,6 +15,23 @@ class MeasureMachinePopup(GridLayout):
     stepText = StringProperty("Step 1 of 10")
     numberOfTimesTestCutRun = -2
     
+    def establishDataConnection(self, data):
+        '''
+        
+        Sets up the data connection between this popup and the shared data object
+        
+        '''
+        
+        print "THIS BIT RAN"
+        
+        self.data = data
+        
+        self.setSprocketsVertical.data      =  data
+        self.setSprocketsVertical.carousel  =  self.carousel
+        
+        self.measureOutChains.data          =  data
+        self.measureOutChains.carousel      =  self.carousel
+    
     def backBtn(self, *args):
         '''
         
@@ -222,7 +239,6 @@ class MeasureMachinePopup(GridLayout):
     def ondismiss_popup(self, event):
        if global_variables._keyboard:
            global_variables._keyboard.unbind(on_key_down=self.keydown_popup)
-
 
     def keydown_popup(self, keyboard, keycode, text, modifiers):
         if (keycode[1] == '0') or (keycode[1] =='numpad0'):

--- a/UIElements/measureOutChains.py
+++ b/UIElements/measureOutChains.py
@@ -8,7 +8,6 @@ class MeasureOutChains(Widget):
     
     '''
     data              =  ObjectProperty(None) #set externally
-    done              =  ObjectProperty(None) #set externally
     
     def stop(self):
         self.data.quick_queue.put("!") 
@@ -18,3 +17,7 @@ class MeasureOutChains(Widget):
     def calibrateChainLengths(self, direction):
         print direction
         self.data.gcode_queue.put("B02 ")
+    
+    def next(self):
+        self.data.gcode_queue.put("B15 ")
+        self.carousel.load_next()

--- a/UIElements/measureOutChains.py
+++ b/UIElements/measureOutChains.py
@@ -1,5 +1,5 @@
 from kivy.uix.widget                      import   Widget
-from kivy.properties                      import   ObjectProperty
+from kivy.properties                      import   ObjectProperty, StringProperty
 
 class MeasureOutChains(Widget):
     '''
@@ -8,6 +8,7 @@ class MeasureOutChains(Widget):
     
     '''
     data              =  ObjectProperty(None) #set externally
+    text              =  StringProperty("")
     
     def stop(self):
         self.data.quick_queue.put("!") 

--- a/UIElements/measureOutChains.py
+++ b/UIElements/measureOutChains.py
@@ -1,0 +1,20 @@
+from kivy.uix.widget                      import   Widget
+from kivy.properties                      import   ObjectProperty
+
+class MeasureOutChains(Widget):
+    '''
+    
+    Provides a standard interface for making both sprockets point vertically
+    
+    '''
+    data              =  ObjectProperty(None) #set externally
+    done              =  ObjectProperty(None) #set externally
+    
+    def stop(self):
+        self.data.quick_queue.put("!") 
+        with self.data.gcode_queue.mutex:
+            self.data.gcode_queue.queue.clear()
+    
+    def calibrateChainLengths(self, direction):
+        print direction
+        self.data.gcode_queue.put("B02 ")

--- a/UIElements/measureOutChains.py
+++ b/UIElements/measureOutChains.py
@@ -4,7 +4,7 @@ from kivy.properties                      import   ObjectProperty, StringPropert
 class MeasureOutChains(Widget):
     '''
     
-    Provides a standard interface for making both sprockets point vertically
+    Provides a standard interface for measuring out a known length of both chains
     
     '''
     data              =  ObjectProperty(None) #set externally
@@ -16,7 +16,6 @@ class MeasureOutChains(Widget):
             self.data.gcode_queue.queue.clear()
     
     def calibrateChainLengths(self, direction):
-        print direction
         self.data.gcode_queue.put("B02 ")
     
     def next(self):

--- a/UIElements/setSprocketsVertical.py
+++ b/UIElements/setSprocketsVertical.py
@@ -1,0 +1,38 @@
+from kivy.uix.widget                      import   Widget
+from kivy.properties                      import   ObjectProperty
+
+class SetSprocketsVertical(Widget):
+    '''
+    
+    Provides a standard interface for making both sprockets point vertically
+    
+    '''
+    data = ObjectProperty(None) #set externally
+    
+    def LeftCW(self):
+        
+        self.data.gcode_queue.put("G91 ")
+        self.data.gcode_queue.put("B09 L.5 ")
+        self.data.gcode_queue.put("G90 ")
+    
+    def LeftCCW(self):
+        
+        self.data.gcode_queue.put("G91 ")
+        self.data.gcode_queue.put("B09 L-.5 ")
+        self.data.gcode_queue.put("G90 ")
+        
+    def RightCW(self):
+        #print "right CW"
+        self.data.gcode_queue.put("G91 ")
+        self.data.gcode_queue.put("B09 R-.5 ")
+        self.data.gcode_queue.put("G90 ")
+    
+    def RightCCW(self):
+        self.data.gcode_queue.put("G91 ")
+        self.data.gcode_queue.put("B09 R.5 ")
+        self.data.gcode_queue.put("G90 ")
+    
+    def setZero(self):
+        #mark that the sprockets are straight up
+        self.data.gcode_queue.put("B06 L0 R0 ");
+        self.carousel.load_next()

--- a/UIElements/setSprocketsVertical.py
+++ b/UIElements/setSprocketsVertical.py
@@ -22,7 +22,6 @@ class SetSprocketsVertical(Widget):
         self.data.gcode_queue.put("G90 ")
         
     def RightCW(self):
-        #print "right CW"
         self.data.gcode_queue.put("G91 ")
         self.data.gcode_queue.put("B09 R-.5 ")
         self.data.gcode_queue.put("G90 ")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -741,11 +741,11 @@
             size_hint_x: rightCol
             Label:
             Button:
-                text: 'Extend\nLeft Chain'
+                text: 'Extend\nChains'
                 on_release: root.calibrateChainLengths('L')
-            Button:
-                text: 'Extend\nRight Chain'
-                on_release: root.calibrateChainLengths('R')
+            #Button:
+            #    text: 'Extend\nRight Chain'
+            #    on_release: root.calibrateChainLengths('R')
             Button:
                 text: 'Stop'
                 on_release: root.stop()

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -751,7 +751,7 @@
                 on_release: root.stop()
             Button:
                 text: 'Next'
-                on_release: root.done()
+                on_release: root.next()
             Label:
 
 <MeasureMachinePopup>:
@@ -1141,6 +1141,24 @@
             cols: 1
             MeasureOutChains:
                 id: measureOutChains
+        #finish
+        GridLayout:
+            cols: 2
+            width: root.width
+            height: root.height
+            GridLayout:
+                cols: 1
+                Label:
+                    text: "The machine now has an accurate reading of the lengths of the chains.\n\nPress finish to close the popup"
+                    size_hint_x: leftCol
+            GridLayout:
+                cols: 1
+                size_hint_x: rightCol
+                Label:
+                Button:
+                    text: 'Finish'
+                    on_release: root.done()
+                Label:
 
 <SimulationCanvas>:
     motorSpacingError:motorSpacingError

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -685,6 +685,42 @@
             text: "Raise"
             on_release: root.zOut()
 
+<SetSprocketsVertical>:
+    #Set sprockets to 12 o'clock
+    GridLayout:
+        cols: 2
+        size_hint: [1,1]
+        width: root.width
+        height: root.height
+        GridLayout:
+            cols: 1
+            Label:
+                text: "Orient each sprocket so that one tooth faces straight up in the 12:00 o'clock position.\n\nIt is important to start with the sprockets in a known configuration. \nUse the buttons to the right to rotate each sprocket so that one tooth points straight up.\nWhen you are ready, press Set Zero"
+                size_hint_x: leftCol
+            Image:
+                source: "./Documentation/Calibrate Machine Dimensions/Sprocket at 12-00.jpg"
+        GridLayout:
+            cols: 1
+            size_hint_x: rightCol
+            Label:
+            Button:
+                text: 'Turn Left Sprocket\n1 degree CCW'
+                on_release: root.LeftCCW()
+            Button:
+                text: 'Turn Left Sprocket\n1 degree CW'
+                on_release: root.LeftCW()
+            Button:
+                text: 'Turn Right Sprocket\n1 degree CCW'
+                on_release: root.RightCCW()
+            Button:
+                text: 'Turn Right Sprocket\n1 degree CW'
+                on_release: root.RightCW()
+            Button:
+                text: 'Set Zero'
+                on_release: root.setZero()
+            Label:
+    
+
 <MeasureMachinePopup>:
     carousel:carousel
     linksTextInput:linksTextInput
@@ -749,35 +785,8 @@
                 Label:
         #Set sprockets to 12 o'clock
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                Label:
-                    text: "Orient each sprocket so that one tooth faces straight up in the 12:00 o'clock position.\n\nIt is important to start with the sprockets in a known configuration. \nUse the buttons to the right to rotate each sprocket so that one tooth points straight up.\nWhen you are ready, press Set Zero"
-                    size_hint_x: leftCol
-                Image:
-                    source: "./Documentation/Calibrate Machine Dimensions/Sprocket at 12-00.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                Button:
-                    text: 'Turn Left Sprocket\n1 degree CCW'
-                    on_release: root.LeftCCW()
-                Button:
-                    text: 'Turn Left Sprocket\n1 degree CW'
-                    on_release: root.LeftCW()
-                Button:
-                    text: 'Turn Right Sprocket\n1 degree CCW'
-                    on_release: root.RightCCW()
-                Button:
-                    text: 'Turn Right Sprocket\n1 degree CW'
-                    on_release: root.RightCW()
-                Button:
-                    text: 'Set Zero'
-                    on_release: root.setZero()
-                Label:
-        #Measure spacing between motors
+            cols: 1
+            SetSprocketsVertical:
         GridLayout:
             cols: 2
             GridLayout:
@@ -924,8 +933,11 @@
                 size_hint_x: rightCol
                 Label:
                 Button:
-                    text: 'Calibrate\nChain Lengths'
-                    on_release: root.calibrateChainLengths()
+                    text: 'Extend\nLeft Chain'
+                    on_release: root.calibrateChainLengths('L')
+                Button:
+                    text: 'Extend\nRight Chain'
+                    on_release: root.calibrateChainLengths('R')
                 Button:
                     text: 'Stop'
                     on_release: root.stopCut()
@@ -1104,6 +1116,7 @@
     
 <CalibrateLengthsPopup>:
     carousel:carousel
+    setSprocketsVertical:setSprocketsVertical
 
     cols: 1
     size: root.size
@@ -1115,37 +1128,9 @@
         #:set leftCol .8
         #:set rightCol .2
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                Label:
-                    text: "Orient each sprocket so that one tooth faces straight up in the 12:00 o'clock position.\n\nIt is important to start with the sprockets in a known configuration. \nUse the buttons to the right to rotate each sprocket so that one tooth points straight up.\nWhen you are ready, press Set Zero"
-                    size_hint_x: leftCol
-                Image:
-                    source: "./Documentation/Calibrate Machine Dimensions/Sprocket at 12-00.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                Button:
-                    text: 'Turn Left Sprocket\n1 degree CCW'
-                    on_release: root.LeftCCW()
-                Button:
-                    text: 'Turn Left Sprocket\n1 degree CW'
-                    on_release: root.LeftCW()
-                Button:
-                    text: 'Turn Right Sprocket\n1 degree CCW'
-                    on_release: root.RightCCW()
-                Button:
-                    text: 'Turn Right Sprocket\n1 degree CW'
-                    on_release: root.RightCW()
-                Button:
-                    text: 'Set Zero'
-                    on_release: root.setZero()
-                Button:
-                    text: 'Close'
-                    on_release: root.done()
-                Label:
+            cols: 1
+            SetSprocketsVertical:
+                id: setSprocketsVertical
         GridLayout:
             cols: 2
             GridLayout:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -689,7 +689,6 @@
     #Set sprockets to 12 o'clock
     GridLayout:
         cols: 2
-        size_hint: [1,1]
         width: root.width
         height: root.height
         GridLayout:
@@ -720,6 +719,40 @@
                 on_release: root.setZero()
             Label:
     
+<MeasureOutChains>:
+    GridLayout:
+        cols: 2
+        width: root.width
+        height: root.height
+        GridLayout:
+            cols: 1
+            size_hint_x: leftCol
+            Label:
+                text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
+                size_hint_x: leftCol
+            GridLayout:
+                cols: 2
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Ready To Calibrate Right Sprocket.jpg"
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Sled Attached.jpg"
+        GridLayout:
+            cols: 1
+            size_hint_x: rightCol
+            Label:
+            Button:
+                text: 'Extend\nLeft Chain'
+                on_release: root.calibrateChainLengths('L')
+            Button:
+                text: 'Extend\nRight Chain'
+                on_release: root.calibrateChainLengths('R')
+            Button:
+                text: 'Stop'
+                on_release: root.stop()
+            Button:
+                text: 'Next'
+                on_release: root.done()
+            Label:
 
 <MeasureMachinePopup>:
     carousel:carousel
@@ -915,36 +948,8 @@
                 Label:
         #measure out chains
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                size_hint_x: leftCol
-                Label:
-                    text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
-                    size_hint_x: leftCol
-                GridLayout:
-                    cols: 2
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Ready To Calibrate Right Sprocket.jpg"
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Sled Attached.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                Button:
-                    text: 'Extend\nLeft Chain'
-                    on_release: root.calibrateChainLengths('L')
-                Button:
-                    text: 'Extend\nRight Chain'
-                    on_release: root.calibrateChainLengths('R')
-                Button:
-                    text: 'Stop'
-                    on_release: root.stopCut()
-                Button:
-                    text: 'Next'
-                    on_release: root.finishChainCalibration()
-                Label:
+            cols: 1
+            
         #set z-axis depth
         GridLayout:
             cols: 2
@@ -1117,6 +1122,7 @@
 <CalibrateLengthsPopup>:
     carousel:carousel
     setSprocketsVertical:setSprocketsVertical
+    measureOutChains:measureOutChains
 
     cols: 1
     size: root.size
@@ -1132,35 +1138,9 @@
             SetSprocketsVertical:
                 id: setSprocketsVertical
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                size_hint_x: leftCol
-                Label:
-                    text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of each chain on the vertical tooth of each sprocket\n as shown in the picture below. Then press Calibrate Chain Lengths\n\nThe correct length of first the left and then the right chain will be measured out\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way\n\nOnce both chains are finished attach the sled, then press Finish"
-                    size_hint_x: leftCol
-                GridLayout:
-                    cols: 3
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Chain On Left Sprocket.jpg"
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Ready To Calibrate Right Sprocket.jpg"
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Sled Attached.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                Button:
-                    text: 'Calibrate\nChain Lengths'
-                    on_release: root.calibrateChainLengths()
-                Button:
-                    text: 'Stop Motor'
-                    on_release: root.stop()
-                Button:
-                    text: 'Finish'
-                    on_release: root.done()
-                Label:
+            cols: 1
+            MeasureOutChains:
+                id: measureOutChains
 
 <SimulationCanvas>:
     motorSpacingError:motorSpacingError

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -771,6 +771,8 @@
     unitsBtnT:unitsBtnT
     enterValuesT:enterValuesT
     cutBtnT:cutBtnT
+    setSprocketsVertical:setSprocketsVertical
+    measureOutChains:measureOutChains
     
     cols: 1
     size: root.size
@@ -820,6 +822,7 @@
         GridLayout:
             cols: 1
             SetSprocketsVertical:
+                id: setSprocketsVertical
         GridLayout:
             cols: 2
             GridLayout:
@@ -949,7 +952,8 @@
         #measure out chains
         GridLayout:
             cols: 1
-            
+            MeasureOutChains:
+                id: measureOutChains
         #set z-axis depth
         GridLayout:
             cols: 2

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -728,7 +728,7 @@
             cols: 1
             size_hint_x: leftCol
             Label:
-                text: "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
+                text: root.text
                 size_hint_x: leftCol
             GridLayout:
                 cols: 2


### PR DESCRIPTION
The behavior of rotating the sprockets to the vertical position and extending the chains to a known length are both behaviors repeated in the chain length calibration and the machine measuring processes so maintaining the same behavior in two places was causing issues. This pull request creates widgets for each behavior which can be used in both places.

It is not ready to merge, just creating the PR to be able to view the diffs more easily for now