### PR TITLE
Add slider to move test cut up and down

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -353,7 +353,9 @@ class MeasureMachinePopup(GridLayout):
         self.data.gcode_queue.put("G17 ")
 
         #(defines the center). Moves up with each attempt
-        self.data.gcode_queue.put("G0 X" +  str(18*self.numberOfTimesTestCutRun) + " Y" + str(-400 + 18*self.numberOfTimesTestCutRun) + "  ")
+        self.data.gcode_queue.put("G0 X0 Y" + str(self.testCutPosSlider.value) + "  ")
+        
+        self.testCutPosSlider.value = self.testCutPosSlider.value + 18 #increment the starting spot
         
         self.data.gcode_queue.put("G91 ")   #Switch to relative mode
 

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1031,7 +1031,7 @@
                 cols: 1
                 size_hint_x: leftCol
                 Label:
-                    text: "To refine these measurements we're going to cut a test shape.\n\nThe test shape consists of two short vertical cuts a known distance apart\n\nBased on the distance between these marks we can dial in the machine settings\n\nThe size of bit used is not critical\nMeasure from the left side of one mark to the left side of the other mark\n\nThe process will repeat until the spacing is accurate to within .5mm\nThe more accurate your measurements, the more accurate your machine will be\n\nPress Cut Test Pattern to begin"
+                    text: "To refine these measurements we're going to cut a test shape.\n\nThe test shape consists of two short vertical cuts a known distance apart\n\nBased on the distance between these marks we can dial in the machine settings\n\nThe slider to the right of the buttons can be used to vertically adjust where the test cut is done\n\nThe size of bit used is not critical\nMeasure from the left side of one mark to the left side of the other mark\n\nThe process will repeat until the spacing is accurate to within .5mm\nThe more accurate your measurements, the more accurate your machine will be\n\nPress Cut Test Pattern to begin"
                 GridLayout:
                     cols: 2
                     Image:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -776,6 +776,7 @@
     cutBtnT:cutBtnT
     setSprocketsVertical:setSprocketsVertical
     measureOutChains:measureOutChains
+    testCutPosSlider:testCutPosSlider
     
     cols: 1
     size: root.size
@@ -1040,30 +1041,42 @@
             GridLayout:
                 cols: 1
                 size_hint_x: rightCol
-                Label:
-                Label:
-                    text: "Measurement:"
-                TextInput:
-                    id:triangleMeasure
-                    disabled: True
-                Button:
-                    text: "MM"
-                    on_release: root.switchUnits()
-                    id: unitsBtnT
-                    disabled: True
-                Button:
-                    text: "Enter Value"
-                    on_release: root.enterTestPaternValuesTriangular()
-                    id: enterValuesT
-                    disabled: True
-                Button:
-                    text: "Cut Test\nPattern"
-                    id: cutBtnT
-                    on_release: root.cutTestPaternTriangular()
-                Button:
-                    text: "Stop\nCut"
-                    on_release: root.stopCut()
-                Label:
+                GridLayout:
+                    cols: 2
+                    GridLayout:
+                        cols: 1
+                        size_hint_x: .8
+                        Label:
+                        Label:
+                            text: "Measurement:"
+                        TextInput:
+                            id:triangleMeasure
+                            disabled: True
+                        Button:
+                            text: "MM"
+                            on_release: root.switchUnits()
+                            id: unitsBtnT
+                            disabled: True
+                        Button:
+                            text: "Enter Value"
+                            on_release: root.enterTestPaternValuesTriangular()
+                            id: enterValuesT
+                            disabled: True
+                        Button:
+                            text: "Cut Test\nPattern"
+                            id: cutBtnT
+                            on_release: root.cutTestPaternTriangular()
+                        Button:
+                            text: "Stop\nCut"
+                            on_release: root.stopCut()
+                        Label:
+                    Slider:
+                        orientation: 'vertical'
+                        min: -400
+                        max:  400
+                        value: -400
+                        id: testCutPosSlider
+                        size_hint_x: .2
         #cut test shape Quadrilateral
         GridLayout:
             cols: 2


### PR DESCRIPTION
Adds a slider to allow you to move where the test pattern is cut on the sheet.

Fixes #465 