### PR TITLE
Use the current value of rotationRadius if it is present

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -331,10 +331,15 @@ class MeasureMachinePopup(GridLayout):
         self.data.config.write()
         
         if self.kinematicsType == 'Triangular':
-            #Set up a good initial guess for the radius
-            print "Rotation radius set to 260"
-            self.data.config.set('Advanced Settings', 'rotationRadius', 260)
-            self.data.config.write()
+             try:
+             	#Get the value if it's already there...
+                 rotationRadius = self.data.config.get('Advanced Settings', 'rotationRadius')
+                 print "Rotation radius is " + str(rotationRadius)
+            except:
+                #Set up a good initial guess for the radius
+                print "Rotation radius set to 260"
+                self.data.config.set('Advanced Settings', 'rotationRadius', 260)
+                self.data.config.write()
             self.carousel.load_next()
         else:
             


### PR DESCRIPTION
Trying to do the calibration step with a top-pantograph linkage (129mm rotationradius), I find that choosing the Triangular calibration writes 260 to rotationradius in groundcontrol.ini overwriting the previous value. This PR looks for the current value and uses that if it is found.