### PR TITLE
Add the target distance to calibration text

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -975,7 +975,7 @@
                 cols: 1
                 size_hint_x: leftCol
                 Label:
-                    text: "To refine these measurements we're going to cut a test shape.\n\nThe test shape consists of two short vertical cuts a known distance apart\n\nBased on the distance between these marks we can dial in the machine settings\n\nThe slider to the right of the buttons can be used to vertically adjust where the test cut is done\n\nThe size of bit used is not critical\nMeasure from the left side of one mark to the left side of the other mark\n\nThe process will repeat until the spacing is accurate to within .5mm\nThe more accurate your measurements, the more accurate your machine will be\n\nPress Cut Test Pattern to begin"
+                    text: "To refine these measurements we're going to cut a test shape.\nThe test shape consists of two short vertical cuts a known distance apart\nBased on the distance between these marks we can dial in the machine settings\n\nThe slider to the right of the buttons can be used to vertically adjust where the test cut is done\n\nThe size of bit used is not critical\nMeasure from the left side of one mark to the left side of the other mark\nThe target distance is 1905mm (75in)\nThe process will repeat until the spacing is accurate to within .5mm\nThe more accurate your measurements, the more accurate your machine will be\n\nPress Cut Test Pattern to begin"
                 GridLayout:
                     cols: 2
                     Image:


### PR DESCRIPTION
Adds the target distance to be measured to the text of the calibration popup

The text now looks like this:

![image](https://user-images.githubusercontent.com/9359447/34016399-9a669b72-e0d6-11e7-8aa7-9f5a1b1d2586.png)

This PR addresses one of the issues raised in #494 