### PR TITLE
Move triangular calibration into object

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -7,6 +7,7 @@ from   kivy.uix.gridlayout                       import   GridLayout
 from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   UIElements.touchNumberInput               import   TouchNumberInput
+from   UIElements.triangularCalibration          import   TriangularCalibration
 from   kivy.uix.popup                            import   Popup
 import global_variables
 
@@ -31,7 +32,10 @@ class MeasureMachinePopup(GridLayout):
         self.measureOutChains.data          =  data
         self.measureOutChains.carousel      =  self.carousel
         self.measureOutChains.text          =  "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
-    
+        
+        self.triangularCalibration.data          =  data
+        self.triangularCalibration.carousel      =  self.carousel
+        
     def backBtn(self, *args):
         '''
         
@@ -110,7 +114,7 @@ class MeasureMachinePopup(GridLayout):
         
         if self.carousel.index == 9:
             #Cut test shape triangular
-            self.data.pushSettings()
+            self.data.pushSettings()  
             self.stepText = "Step 10 of 10"
             self.goFwdBtn.disabled = False
             
@@ -144,30 +148,25 @@ class MeasureMachinePopup(GridLayout):
         each sprocket to 12:00
         
         '''
-        print "define initial state"
         self.data.gcode_queue.put("B06 L0 R0 ");
         self.carousel.load_next()
     
     def LeftCW(self):
-        print "left CW"
         self.data.gcode_queue.put("G91 ")
         self.data.gcode_queue.put("B09 L.5 F100 ")
         self.data.gcode_queue.put("G90 ")
     
     def LeftCCW(self):
-        print "left CCW"
         self.data.gcode_queue.put("G91 ")
         self.data.gcode_queue.put("B09 L-.5 F100 ")
         self.data.gcode_queue.put("G90 ")
         
     def RightCW(self):
-        print "right CW"
         self.data.gcode_queue.put("G91 ")
         self.data.gcode_queue.put("B09 R-.5 F100 ")
         self.data.gcode_queue.put("G90 ")
     
     def RightCCW(self):
-        print "right CCW"
         self.data.gcode_queue.put("G91 ")
         self.data.gcode_queue.put("B09 R.5 F100 ")
         self.data.gcode_queue.put("G90 ")
@@ -345,45 +344,6 @@ class MeasureMachinePopup(GridLayout):
             
             self.carousel.load_slide(self.carousel.slides[10])
     
-    def cutTestPaternTriangular(self):
-        
-        #Credit for this test pattern to David Lang
-        self.data.units = "MM"
-        self.data.gcode_queue.put("G21 ")
-        self.data.gcode_queue.put("G90  ") #Switch to absolute mode
-        self.data.gcode_queue.put("G40 ")
-
-        self.data.gcode_queue.put("G0 Z5 ")
-        self.data.gcode_queue.put("G0 X0 Y0  ")
-        self.data.gcode_queue.put("G17 ")
-
-        #(defines the center). Moves up with each attempt
-        self.data.gcode_queue.put("G0 X0 Y" + str(self.testCutPosSlider.value) + "  ")
-        
-        self.testCutPosSlider.value = self.testCutPosSlider.value + 18 #increment the starting spot
-        
-        self.data.gcode_queue.put("G91 ")   #Switch to relative mode
-
-        self.data.gcode_queue.put("G0 X-902.5 ")
-        self.data.gcode_queue.put("G1 Z-7 F500 ")
-        self.data.gcode_queue.put("G1 Y-20 ")
-        self.data.gcode_queue.put("G1 Z7 ")
-        self.data.gcode_queue.put("G0 X1905 Y20 ")
-        self.data.gcode_queue.put("G1 Z-7 ")
-        self.data.gcode_queue.put("G1 Y-20 ")
-        self.data.gcode_queue.put("G1 Z5 ")
-        self.data.gcode_queue.put("G0 X-900 Y500 ")
-        
-        
-        self.data.gcode_queue.put("G90  ") #Switch back to absolute mode
-        
-        self.numberOfTimesTestCutRun = self.numberOfTimesTestCutRun + 1
-        self.cutBtnT.text = "Re-Cut Test\nPattern"
-        self.cutBtnT.disabled         = True
-        self.triangleMeasure.disabled = False
-        self.unitsBtnT.disabled       = False
-        self.enterValuesT.disabled    = False
-    
     def cutTestPatern(self):
         
         #Credit for this test pattern to DavidLang
@@ -448,43 +408,6 @@ class MeasureMachinePopup(GridLayout):
             self.data.config.set('Maslow Settings', 'sledWidth', str(newSledSpacing))
             self.data.config.write()
             self.cutBtn.disabled = False
-            self.data.pushSettings()
-    
-    def enterTestPaternValuesTriangular(self):
-        
-        print "got to enter test values"
-        
-        dist = 0
-        
-        try:
-            dist = float(self.triangleMeasure.text)
-        except:
-            self.data.message_queue.put("Message: Couldn't make that into a number")
-            return
-        
-        if self.unitsBtn.text == 'Inches':
-            dist = dist*25.4
-        
-        dist = 1905 - dist #1905 is expected test spacing in mm. dist is greater than zero if the length is too long, less than zero if if is too short
-        
-        print "The error is: "
-        print dist
-        
-        acceptableTolerance = .5
-        
-        if abs(dist) < acceptableTolerance:               #if we're fully calibrated
-            self.carousel.load_slide(self.carousel.slides[11])
-        else:
-            amtToChange = -.9*dist
-            
-            print "so we are going to adjust the motor spacing by: "
-            print amtToChange
-            
-            newSledSpacing = float(self.data.config.get('Advanced Settings', 'rotationRadius')) + amtToChange
-            print "Now trying spacing: " + str(newSledSpacing)
-            self.data.config.set('Advanced Settings', 'rotationRadius', str(newSledSpacing))
-            self.data.config.write()
-            self.cutBtnT.disabled = False
             self.data.pushSettings()
     
     def stopCut(self):

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -88,6 +88,8 @@ class TriangularCalibration(Widget):
         self.data.quick_queue.put("!") 
         with self.data.gcode_queue.mutex:
             self.data.gcode_queue.queue.clear()
+        
+        self.cutBtnT.disabled = False
     
     def switchUnits(self):
         if self.unitsBtnT.text == 'MM':

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -1,0 +1,96 @@
+from kivy.uix.widget                      import   Widget
+from kivy.properties                      import   ObjectProperty
+
+class TriangularCalibration(Widget):
+    '''
+    
+    Provides a standard interface for running the calibration test pattern for triangular kinematics 
+    
+    '''
+    data                         =  ObjectProperty(None) #linked externally
+    numberOfTimesTestCutRun      = -2
+    
+    def cutTestPaternTriangular(self):
+        
+        #Credit for this test pattern to David Lang
+        self.data.units = "MM"
+        self.data.gcode_queue.put("G21 ")
+        self.data.gcode_queue.put("G90  ") #Switch to absolute mode
+        self.data.gcode_queue.put("G40 ")
+
+        self.data.gcode_queue.put("G0 Z5 ")
+        self.data.gcode_queue.put("G0 X0 Y0  ")
+        self.data.gcode_queue.put("G17 ")
+
+        #(defines the center). Moves up with each attempt
+        self.data.gcode_queue.put("G0 X0 Y" + str(self.testCutPosSlider.value) + "  ")
+        
+        self.testCutPosSlider.value = self.testCutPosSlider.value + 18 #increment the starting spot
+        
+        self.data.gcode_queue.put("G91 ")   #Switch to relative mode
+
+        self.data.gcode_queue.put("G0 X-902.5 ")
+        self.data.gcode_queue.put("G1 Z-7 F500 ")
+        self.data.gcode_queue.put("G1 Y-20 ")
+        self.data.gcode_queue.put("G1 Z7 ")
+        self.data.gcode_queue.put("G0 X1905 Y20 ")
+        self.data.gcode_queue.put("G1 Z-7 ")
+        self.data.gcode_queue.put("G1 Y-20 ")
+        self.data.gcode_queue.put("G1 Z5 ")
+        self.data.gcode_queue.put("G0 X-900 Y500 ")
+        
+        
+        self.data.gcode_queue.put("G90  ") #Switch back to absolute mode
+        
+        self.numberOfTimesTestCutRun = self.numberOfTimesTestCutRun + 1
+        self.cutBtnT.text = "Re-Cut Test\nPattern"
+        self.cutBtnT.disabled         = True
+        self.triangleMeasure.disabled = False
+        self.unitsBtnT.disabled       = False
+        self.enterValuesT.disabled    = False
+    
+    def enterTestPaternValuesTriangular(self):
+        
+        dist = 0
+        
+        try:
+            dist = float(self.triangleMeasure.text)
+        except:
+            self.data.message_queue.put("Message: Couldn't make that into a number")
+            return
+        
+        if self.unitsBtnT.text == 'Inches':
+            dist = dist*25.4
+        
+        dist = 1905 - dist #1905 is expected test spacing in mm. dist is greater than zero if the length is too long, less than zero if if is too short
+        
+        print "The error is: "
+        print dist
+        
+        acceptableTolerance = .5
+        
+        if abs(dist) < acceptableTolerance:               #if we're fully calibrated
+            self.carousel.load_slide(self.carousel.slides[11])
+        else:
+            amtToChange = -.9*dist
+            
+            print "so we are going to adjust the motor spacing by: "
+            print amtToChange
+            
+            newSledSpacing = float(self.data.config.get('Advanced Settings', 'rotationRadius')) + amtToChange
+            print "Now trying spacing: " + str(newSledSpacing)
+            self.data.config.set('Advanced Settings', 'rotationRadius', str(newSledSpacing))
+            self.data.config.write()
+            self.cutBtnT.disabled = False
+            self.data.pushSettings()
+    
+    def stopCut(self):
+        self.data.quick_queue.put("!") 
+        with self.data.gcode_queue.mutex:
+            self.data.gcode_queue.queue.clear()
+    
+    def switchUnits(self):
+        if self.unitsBtnT.text == 'MM':
+            self.unitsBtnT.text = 'Inches'
+        else:
+            self.unitsBtnT.text = 'MM'

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -628,6 +628,67 @@
                 # color: [1,0,0,1]
                 on_release: root.stopZMove()
 
+<TriangularCalibration>:
+    testCutPosSlider:testCutPosSlider
+    triangleMeasure:triangleMeasure
+    unitsBtnT:unitsBtnT
+    cutBtnT:cutBtnT
+    enterValuesT:enterValuesT
+    
+    GridLayout:
+        cols: 2
+        width: root.width
+        height: root.height
+        GridLayout:
+            cols: 1
+            size_hint_x: leftCol
+            Label:
+                text: "To refine these measurements we're going to cut a test shape.\nThe test shape consists of two short vertical cuts a known distance apart\nBased on the distance between these marks we can dial in the machine settings\n\nThe slider to the right of the buttons can be used to vertically adjust where the test cut is done\n\nThe size of bit used is not critical\nMeasure from the left side of one mark to the left side of the other mark\nThe target distance is 1905mm (75in)\nThe process will repeat until the spacing is accurate to within .5mm\nThe more accurate your measurements, the more accurate your machine will be\n\nPress Cut Test Pattern to begin"
+            GridLayout:
+                cols: 2
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Test Shape Preview Triangular.JPG"
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Measure Test Shape Horizontal.jpg"
+        GridLayout:
+            cols: 1
+            size_hint_x: rightCol
+            GridLayout:
+                cols: 2
+                GridLayout:
+                    cols: 1
+                    size_hint_x: .8
+                    Label:
+                    Label:
+                        text: "Measurement:"
+                    TextInput:
+                        id:triangleMeasure
+                        disabled: True
+                    Button:
+                        text: "MM"
+                        on_release: root.switchUnits()
+                        id: unitsBtnT
+                        disabled: True
+                    Button:
+                        text: "Enter Value"
+                        on_release: root.enterTestPaternValuesTriangular()
+                        id: enterValuesT
+                        disabled: True
+                    Button:
+                        text: "Cut Test\nPattern"
+                        id: cutBtnT
+                        on_release: root.cutTestPaternTriangular()
+                    Button:
+                        text: "Stop\nCut"
+                        on_release: root.stopCut()
+                    Label:
+                Slider:
+                    orientation: 'vertical'
+                    min: -400
+                    max:  400
+                    value: -400
+                    id: testCutPosSlider
+                    size_hint_x: .2
 
 <SetSprocketsVertical>:
     #Set sprockets to 12 o'clock
@@ -714,13 +775,9 @@
     unitsBtn:unitsBtn
     enterValues:enterValues
     zAxisActiveSwitch:zAxisActiveSwitch
-    triangleMeasure: triangleMeasure
-    unitsBtnT:unitsBtnT
-    enterValuesT:enterValuesT
-    cutBtnT:cutBtnT
     setSprocketsVertical:setSprocketsVertical
     measureOutChains:measureOutChains
-    testCutPosSlider:testCutPosSlider
+    triangularCalibration:triangularCalibration
     
     cols: 1
     size: root.size
@@ -970,57 +1027,9 @@
                 Label:
         #cut test shape Triangular
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                size_hint_x: leftCol
-                Label:
-                    text: "To refine these measurements we're going to cut a test shape.\nThe test shape consists of two short vertical cuts a known distance apart\nBased on the distance between these marks we can dial in the machine settings\n\nThe slider to the right of the buttons can be used to vertically adjust where the test cut is done\n\nThe size of bit used is not critical\nMeasure from the left side of one mark to the left side of the other mark\nThe target distance is 1905mm (75in)\nThe process will repeat until the spacing is accurate to within .5mm\nThe more accurate your measurements, the more accurate your machine will be\n\nPress Cut Test Pattern to begin"
-                GridLayout:
-                    cols: 2
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Test Shape Preview Triangular.JPG"
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Measure Test Shape Horizontal.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                GridLayout:
-                    cols: 2
-                    GridLayout:
-                        cols: 1
-                        size_hint_x: .8
-                        Label:
-                        Label:
-                            text: "Measurement:"
-                        TextInput:
-                            id:triangleMeasure
-                            disabled: True
-                        Button:
-                            text: "MM"
-                            on_release: root.switchUnits()
-                            id: unitsBtnT
-                            disabled: True
-                        Button:
-                            text: "Enter Value"
-                            on_release: root.enterTestPaternValuesTriangular()
-                            id: enterValuesT
-                            disabled: True
-                        Button:
-                            text: "Cut Test\nPattern"
-                            id: cutBtnT
-                            on_release: root.cutTestPaternTriangular()
-                        Button:
-                            text: "Stop\nCut"
-                            on_release: root.stopCut()
-                        Label:
-                    Slider:
-                        orientation: 'vertical'
-                        min: -400
-                        max:  400
-                        value: -400
-                        id: testCutPosSlider
-                        size_hint_x: .2
+            cols: 1
+            TriangularCalibration:
+                id: triangularCalibration
         #cut test shape Quadrilateral
         GridLayout:
             cols: 2


### PR DESCRIPTION
Not a super sexy pull request with new features, just moving the triangular calibration GUI into a new object as part of an effort to break up big files (in this case measureMachinePopup.py) into smaller more managable files which can be reused in multiple places if needed