### PR TITLE
Ensure Machine is Ready; Log Inc Messages Immediately

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -15,7 +15,7 @@ class SerialPortThread(MakesmithInitFuncs):
     
     '''
     
-    machineIsReadyForData      = False
+    machineIsReadyForData      = False # Tracks whether last command was acked
     lastWriteTime              = time.time()
     bufferSpace                = 256
     lengthOfLastLineStack      =  Queue.Queue()
@@ -39,6 +39,7 @@ class SerialPortThread(MakesmithInitFuncs):
         
         self.bufferSpace       = self.bufferSpace - len(message)
         self.lengthOfLastLineStack.put(len(message))
+        machineIsReadyForData = False
         
         message = message.encode()
         try:
@@ -113,6 +114,7 @@ class SerialPortThread(MakesmithInitFuncs):
                 
                 #Check if a line has been completed
                 if lineFromMachine == "ok\r\n":
+                    machineIsReadyForData = True
                     if self.lengthOfLastLineStack.empty() != True:                                     #if we've sent lines to the machine
                         self.bufferSpace = self.bufferSpace + self.lengthOfLastLineStack.get_nowait()    #free up that space in the buffer
                 
@@ -128,14 +130,14 @@ class SerialPortThread(MakesmithInitFuncs):
                     self._write(command)
                 
                 #send regular instructions to the machine if there are any
-                if self.bufferSpace == 256:
+                if self.bufferSpace == 256 and machineIsReadyForData:
                     
                     if self.data.gcode_queue.empty() != True:
                         command = self.data.gcode_queue.get_nowait() + " "
                         self._write(command)
                 
                 #Send the next line of gcode to the machine if we're running a program
-                if self.bufferSpace == 256:#> len(self.data.gcode[self.data.gcodeIndex]):
+                if self.bufferSpace == 256 and machineIsReadyForData:#> len(self.data.gcode[self.data.gcodeIndex]):
                     if self.data.uploadFlag:
                         self._write(self.data.gcode[self.data.gcodeIndex])
                         

--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -6,6 +6,7 @@ from kivy.properties                                  import OptionProperty
 from kivy.properties                                  import NumericProperty
 from kivy.event                                       import EventDispatcher
 from DataStructures.logger                            import   Logger
+from DataStructures.loggingQueue                      import   LoggingQueue
 import Queue
 
 class Data(EventDispatcher):
@@ -75,7 +76,7 @@ class Data(EventDispatcher):
     '''
     Queues
     '''
-    message_queue   =  Queue.Queue()
+    message_queue   =  LoggingQueue(logger)
     gcode_queue     =  Queue.Queue()
     quick_queue     =  Queue.Queue()
     

--- a/DataStructures/loggingQueue.py
+++ b/DataStructures/loggingQueue.py
@@ -1,0 +1,19 @@
+'''
+
+This module provides a simple addition to the Queue, which is that it logs
+puts to the Queue immediately.
+
+'''
+
+from Queue import Queue
+
+
+class LoggingQueue(Queue, object):
+    def __init__(self, logger):
+        self.logger = logger
+        super(LoggingQueue, self).__init__()
+    
+    def put(self, msg):
+        self.logger.writeToLog(msg)
+        return super(LoggingQueue, self).put(msg)
+    

--- a/main.py
+++ b/main.py
@@ -587,8 +587,6 @@ class GroundControlApp(App):
         while not self.data.message_queue.empty(): #if there is new data to be read
             message = self.data.message_queue.get()
             
-            self.data.logger.writeToLog(message)
-            
             if message[0] == "<":
                 self.setPosOnScreen(message)
             elif message[0] == "[":


### PR DESCRIPTION
There was no check for the 'ok' command from the firmware before sending the first message.  This is likely why PR #405 and commit 6c934aa which sent a blank line on startup helped, becuase only the first command could be sent without an ok.  Removed the kludge of a blank command and it seems to work well.

This may also fix the issues reported in this post:
https://forums.maslowcnc.com/t/unable-to-execute-command-machine-settings-not-yet-received/1517

Also added a new child class of Queue which logs the messages to the logger on put rather than waiting for the process to get them out of the queue. The get method was resulting in non-sequential incoming and outgoing messages in the log because outgoing messages were logged immediately.  This makes the log much more helpful.