### PR TITLE
Add a sanity check to make sure that the values entered are realistic…

### DIFF
--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -71,7 +71,7 @@ class TriangularCalibration(Widget):
         maximumRealisticError = 300
         
         if abs(errorAmt) > maximumRealisticError:
-            self.data.message_queue.put('Message: ' + str(dist) + ' is ' + str(errorAmt) + 'away from the target distance of 1905mm which seems too larget to be real.')
+            self.data.message_queue.put('Message: ' + str(dist) + 'mm is ' + str(errorAmt) + 'mm away from the target distance of 1905mm which seems wrong. This measurement will be ignored.')
         elif abs(errorAmt) < acceptableTolerance:               #if we're fully calibrated
             self.carousel.load_slide(self.carousel.slides[11])
         else:

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -62,17 +62,20 @@ class TriangularCalibration(Widget):
         if self.unitsBtnT.text == 'Inches':
             dist = dist*25.4
         
-        dist = 1905 - dist #1905 is expected test spacing in mm. dist is greater than zero if the length is too long, less than zero if if is too short
+        errorAmt = 1905 - dist #1905 is expected test spacing in mm. dist is greater than zero if the length is too long, less than zero if if is too short
         
         print "The error is: "
-        print dist
+        print errorAmt
         
         acceptableTolerance = .5
+        maximumRealisticError = 300
         
-        if abs(dist) < acceptableTolerance:               #if we're fully calibrated
+        if abs(errorAmt) > maximumRealisticError:
+            self.data.message_queue.put('Message: ' + str(dist) + ' is ' + str(errorAmt) + 'away from the target distance of 1905mm which seems too larget to be real.')
+        elif abs(errorAmt) < acceptableTolerance:               #if we're fully calibrated
             self.carousel.load_slide(self.carousel.slides[11])
         else:
-            amtToChange = -.9*dist
+            amtToChange = -.9*errorAmt
             
             print "so we are going to adjust the motor spacing by: "
             print amtToChange

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -71,7 +71,7 @@ class TriangularCalibration(Widget):
         maximumRealisticError = 300
         
         if abs(errorAmt) > maximumRealisticError:
-            self.data.message_queue.put('Message: ' + str(dist) + 'mm is ' + str(errorAmt) + 'mm away from the target distance of 1905mm which seems wrong. This measurement will be ignored.')
+            self.data.message_queue.put('Message: ' + str(dist) + 'mm is ' + str(errorAmt) + 'mm away from the target distance of 1905mm which seems wrong.\nPlease check the number and enter it again.')
         elif abs(errorAmt) < acceptableTolerance:               #if we're fully calibrated
             self.carousel.load_slide(self.carousel.slides[11])
         else:

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -48,6 +48,8 @@ class TriangularCalibration(Widget):
         self.triangleMeasure.disabled = False
         self.unitsBtnT.disabled       = False
         self.enterValuesT.disabled    = False
+        
+        self.enterValuesT.disabled = False
     
     def enterTestPaternValuesTriangular(self):
         
@@ -86,6 +88,8 @@ class TriangularCalibration(Widget):
             self.data.config.write()
             self.cutBtnT.disabled = False
             self.data.pushSettings()
+            
+            self.enterValuesT.disabled = True              #disable the button so the same number cannot be entered twice
     
     def stopCut(self):
         self.data.quick_queue.put("!") 


### PR DESCRIPTION
… in triangular calibration

We have had issues with this text box accepting any number. If the number is not a realistic number say (1,000,000) mm the machine will still do it's best to find a calibration which works for that number resulting in nonsense calibration (like a negative rotation radius). This pull request adds a sanity check which limits the entered value to +-300mm of the expected 1905mm distance

I have not had a chance to test this and would like to merge it after the release on Wednesday because I don't want to make too many changes right before the release for fear of bugs slipping through