### PR TITLE
Add switch units option to number input

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -351,8 +351,7 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
         self.targetWidget = target
         
-        self.popupContent = TouchNumberInput(done=self.dismiss_popup)
-        self.popupContent.data = self.data
+        self.popupContent = TouchNumberInput(done=self.dismiss_popup, data=self.data)
         self._popup = Popup(title="Change increment size of machine movement", content=self.popupContent,
                             size_hint=(0.9, 0.9))
         self._popup.open()

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -352,6 +352,7 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.targetWidget = target
         
         self.popupContent = TouchNumberInput(done=self.dismiss_popup)
+        self.popupContent.data = self.data
         self._popup = Popup(title="Change increment size of machine movement", content=self.popupContent,
                             size_hint=(0.9, 0.9))
         self._popup.open()

--- a/UIElements/touchNumberInput.py
+++ b/UIElements/touchNumberInput.py
@@ -10,6 +10,12 @@ from   kivy.properties                           import   StringProperty
 class TouchNumberInput(GridLayout):
     done   = ObjectProperty(None)
     
+    def __init__(self,**kwargs):
+        self.data = kwargs.get('data')
+        super(TouchNumberInput,self).__init__(**kwargs)
+        
+        self.unitsBtn.text = self.data.units
+    
     def addText(self, text):
         '''
         

--- a/UIElements/touchNumberInput.py
+++ b/UIElements/touchNumberInput.py
@@ -17,3 +17,16 @@ class TouchNumberInput(GridLayout):
         
         '''
         self.textInput.text = self.textInput.text + text
+    
+    def switchUnits(self):
+        '''
+        
+        Switch the units of the entered number
+        
+        '''
+        if self.data.units == "INCHES":
+            self.data.units = "MM"
+            self.unitsBtn.text = 'MM'
+        else:
+            self.data.units = "INCHES"
+            self.unitsBtn.text = 'INCHES'

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -540,13 +540,22 @@
 
 <TouchNumberInput>:
     textInput:textInput
+    unitsBtn:unitsBtn
     cols: 1
     size: root.size
     pos: root.pos
-    TextInput:
+    GridLayout:
+        cols: 2
         size_hint_y:.25
-        font_size: self.height - 5
-        id:textInput
+        TextInput:
+            size_hint_x:.8
+            font_size: self.height - 5
+            id:textInput
+        Button:
+            size_hint_x: .2
+            text: 'MM'
+            id: unitsBtn
+            on_release: root.switchUnits()
     GridLayout:
         cols: 3
         Button:


### PR DESCRIPTION
Add a units button to the popup for entering distances. It was easy to switch units before from outside the popup, but I would like to be able to use this as a general purpose popup for entering distances 


![image](https://user-images.githubusercontent.com/9359447/34183510-05164754-e4d0-11e7-9153-d71c4dda2b1f.png)
