### PR TITLE
Fix issue where files in light view do not render fully

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -262,7 +262,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                         Color(1, 0, 0)
                         radius = 2
                     Line(circle=(self.xPosition , self.yPosition, radius), group = 'gcode')
-                    Color(1, 1, 1)
+                    Color(self.data.drawingColor[0], self.data.drawingColor[1], self.data.drawingColor[2])
             
             self.xPosition = xTarget
             self.yPosition = yTarget


### PR DESCRIPTION
There was an issue where some files would not fully display on the light theme because the line color was incorrectly set to white

Fixes #505 

![image](https://user-images.githubusercontent.com/9359447/34272617-c239dc44-e645-11e7-9489-1d86ee85fd76.png)
