### PR TITLE
fix vertical placement slider logic

### DIFF
--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -37,7 +37,11 @@ class TriangularCalibration(Widget):
         self.data.gcode_queue.put("G1 Z-7 ")
         self.data.gcode_queue.put("G1 Y-20 ")
         self.data.gcode_queue.put("G1 Z5 ")
-        self.data.gcode_queue.put("G0 X-900 Y500 ")
+        if self.testCutPosSlider.value <= 0:
+            self.data.gcode_queue.put("G0 X-900 Y400 ")
+        else:
+            self.data.gcode_queue.put("G0 X-900 Y-400 ")
+        
         
         
         self.data.gcode_queue.put("G90  ") #Switch back to absolute mode


### PR DESCRIPTION
With the vertical placement slider of the Triangular Calibration step at the top of its range (in the neighborhood of +388mm judging by the log), after making the cuts, the sled tries to move 500mm above that level. That would be above the top of a 1220mm sheet.
If the cut level is above Y=0, make the sled move in the negative Y directionn after the cut instead?
The move is currently 500mm, that gets pretty close to the edge when starting from the middle. Lowering that to 400...
See issue#510