### PR TITLE
Use Density-independent Pixels for correct placement

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -30,7 +30,7 @@
     
     BoxLayout:
         orientation: 'horizontal'
-        pos: (0, root.height - 60)
+        pos: (0, root.height - dp(60)
         size_hint: (.4,None)
         height: dp(60)
 


### PR DESCRIPTION
Action and Settings buttons are correctly drawn using Density-independent Pixels, but the placement used the old unscaled value.
Tested on Win10 and OSX