### PR TITLE
Use touch input during calibration

### DIFF
--- a/UIElements/touchNumberInput.py
+++ b/UIElements/touchNumberInput.py
@@ -6,6 +6,7 @@ This allows the user to touch or keyboard input a number when it is the content 
 from   kivy.uix.gridlayout                       import   GridLayout
 from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
+import global_variables
 
 class TouchNumberInput(GridLayout):
     done   = ObjectProperty(None)
@@ -15,6 +16,43 @@ class TouchNumberInput(GridLayout):
         super(TouchNumberInput,self).__init__(**kwargs)
         
         self.unitsBtn.text = self.data.units
+        
+        if global_variables._keyboard:
+            global_variables._keyboard.bind(on_key_down=self.keydown_popup)
+            self.bind(on_dismiss=self.ondismiss_popup)
+        
+    
+    def keydown_popup(self, keyboard, keycode, text, modifiers):
+        if (keycode[1] == '0') or (keycode[1] =='numpad0'):
+            self.addText('0')
+        elif (keycode[1] == '1') or (keycode[1] =='numpad1'):
+            self.addText('1')
+        elif (keycode[1] == '2') or (keycode[1] =='numpad2'):
+            self.addText('2')
+        elif (keycode[1] == '3') or (keycode[1] =='numpad3'):
+            self.addText('3')
+        elif (keycode[1] == '4') or (keycode[1] =='numpad4'):
+            self.addText('4')
+        elif (keycode[1] == '5') or (keycode[1] =='numpad5'):
+            self.addText('5')
+        elif (keycode[1] == '6') or (keycode[1] =='numpad6'):
+            self.addText('6')
+        elif (keycode[1] == '7') or (keycode[1] =='numpad7'):
+            self.addText('7')
+        elif (keycode[1] == '8') or (keycode[1] =='numpad8'):
+            self.addText('8')
+        elif (keycode[1] == '9') or (keycode[1] =='numpad9'):
+            self.addText('9')
+        elif (keycode[1] == '.') or (keycode[1] =='numpaddecimal'):
+            self.addText('.')
+        elif (keycode[1] == 'backspace'):
+            self.textInput.text = self.textInput.text[:-1]         
+        elif (keycode[1] == 'enter') or (keycode[1] =='numpadenter'):
+            self.done()
+        elif (keycode[1] == 'escape'):     # abort entering a number, keep the old number
+            self.textInput.text = ''    # clear text so it isn't converted to a number
+            self.done()
+        return True     # always swallow keypresses since this is a modal dialog
     
     def addText(self, text):
         '''
@@ -36,3 +74,7 @@ class TouchNumberInput(GridLayout):
         else:
             self.data.units = "INCHES"
             self.unitsBtn.text = 'INCHES'
+    
+    def ondismiss_popup(self, event):
+        if global_variables._keyboard:
+            global_variables._keyboard.unbind(on_key_down=self.keydown_popup)

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -1,5 +1,7 @@
 from kivy.uix.widget                      import   Widget
 from kivy.properties                      import   ObjectProperty
+from   UIElements.touchNumberInput        import   TouchNumberInput
+from   kivy.uix.popup                     import   Popup
 
 class TriangularCalibration(Widget):
     '''
@@ -49,8 +51,6 @@ class TriangularCalibration(Widget):
         self.numberOfTimesTestCutRun = self.numberOfTimesTestCutRun + 1
         self.cutBtnT.text = "Re-Cut Test\nPattern"
         self.cutBtnT.disabled         = True
-        self.triangleMeasure.disabled = False
-        self.unitsBtnT.disabled       = False
         self.enterValuesT.disabled    = False
         
         self.enterValuesT.disabled = False
@@ -107,3 +107,25 @@ class TriangularCalibration(Widget):
             self.unitsBtnT.text = 'Inches'
         else:
             self.unitsBtnT.text = 'MM'
+            
+    def enterDist(self):
+        self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
+        self._popup = Popup(title="Enter Measured Distance", content=self.popupContent,
+                            size_hint=(0.9, 0.9))
+        self._popup.open()
+    
+    def dismiss_popup(self):
+        '''
+        
+        Close The Pop-up to enter distance information
+        
+        '''
+        try:
+            numberEntered = float(self.popupContent.textInput.text)
+            print "number entered: "
+            print numberEntered
+            print "Units: "
+            print self.data.units
+        except:
+            pass                                                             #If what was entered cannot be converted to a number, leave the value the same
+        self._popup.dismiss()

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -1,7 +1,8 @@
-from kivy.uix.widget                      import   Widget
-from kivy.properties                      import   ObjectProperty
+from   kivy.uix.widget                    import   Widget
+from   kivy.properties                    import   ObjectProperty
 from   UIElements.touchNumberInput        import   TouchNumberInput
 from   kivy.uix.popup                     import   Popup
+import global_variables
 
 class TriangularCalibration(Widget):
     '''
@@ -100,6 +101,11 @@ class TriangularCalibration(Widget):
     
     
     def enterDist(self):
+        '''
+        
+        Called when the "Enter Measurement" button is pressed
+        
+        '''
         self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
         self._popup = Popup(title="Enter Measured Distance", content=self.popupContent,
                             size_hint=(0.9, 0.9))

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -55,17 +55,13 @@ class TriangularCalibration(Widget):
         
         self.enterValuesT.disabled = False
     
-    def enterTestPaternValuesTriangular(self):
+    def enterTestPaternValuesTriangular(self, dist):
+        '''
         
-        dist = 0
+        Takes the measured distance and uses it to determine a new distance to try
         
-        try:
-            dist = float(self.triangleMeasure.text)
-        except:
-            self.data.message_queue.put("Message: Couldn't make that into a number")
-            return
-        
-        if self.unitsBtnT.text == 'Inches':
+        '''
+        if self.data.units == 'INCHES':
             dist = dist*25.4
         
         errorAmt = 1905 - dist #1905 is expected test spacing in mm. dist is greater than zero if the length is too long, less than zero if if is too short
@@ -102,12 +98,7 @@ class TriangularCalibration(Widget):
         
         self.cutBtnT.disabled = False
     
-    def switchUnits(self):
-        if self.unitsBtnT.text == 'MM':
-            self.unitsBtnT.text = 'Inches'
-        else:
-            self.unitsBtnT.text = 'MM'
-            
+    
     def enterDist(self):
         self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
         self._popup = Popup(title="Enter Measured Distance", content=self.popupContent,
@@ -122,10 +113,8 @@ class TriangularCalibration(Widget):
         '''
         try:
             numberEntered = float(self.popupContent.textInput.text)
-            print "number entered: "
-            print numberEntered
-            print "Units: "
-            print self.data.units
+            self.enterTestPaternValuesTriangular(numberEntered)
         except:
+            self.data.message_queue.put("Message: Unable to make that into a number")
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -8,7 +8,6 @@ from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   UIElements.touchNumberInput               import   TouchNumberInput
 from   kivy.uix.popup                            import   Popup
-import global_variables
 
 class ZAxisPopupContent(GridLayout):
     done   = ObjectProperty(None)
@@ -27,45 +26,7 @@ class ZAxisPopupContent(GridLayout):
         self._popup = Popup(title="Change increment size of machine movement", content=self.popupContent,
                             size_hint=(0.9, 0.9))
         self._popup.open()
-        if global_variables._keyboard:
-            global_variables._keyboard.bind(on_key_down=self.keydown_popup)
-            self._popup.bind(on_dismiss=self.ondismiss_popup)
-
-    def ondismiss_popup(self, event):
-        if global_variables._keyboard:
-            global_variables._keyboard.unbind(on_key_down=self.keydown_popup)
-
-    def keydown_popup(self, keyboard, keycode, text, modifiers):
-        if (keycode[1] == '0') or (keycode[1] =='numpad0'):
-            self.popupContent.addText('0')
-        elif (keycode[1] == '1') or (keycode[1] =='numpad1'):
-            self.popupContent.addText('1')
-        elif (keycode[1] == '2') or (keycode[1] =='numpad2'):
-            self.popupContent.addText('2')
-        elif (keycode[1] == '3') or (keycode[1] =='numpad3'):
-            self.popupContent.addText('3')
-        elif (keycode[1] == '4') or (keycode[1] =='numpad4'):
-            self.popupContent.addText('4')
-        elif (keycode[1] == '5') or (keycode[1] =='numpad5'):
-            self.popupContent.addText('5')
-        elif (keycode[1] == '6') or (keycode[1] =='numpad6'):
-            self.popupContent.addText('6')
-        elif (keycode[1] == '7') or (keycode[1] =='numpad7'):
-            self.popupContent.addText('7')
-        elif (keycode[1] == '8') or (keycode[1] =='numpad8'):
-            self.popupContent.addText('8')
-        elif (keycode[1] == '9') or (keycode[1] =='numpad9'):
-            self.popupContent.addText('9')
-        elif (keycode[1] == '.') or (keycode[1] =='numpaddecimal'):
-            self.popupContent.addText('.')
-        elif (keycode[1] == 'backspace'):
-            self.popupContent.textInput.text = self.popupContent.textInput.text[:-1]         
-        elif (keycode[1] == 'enter') or (keycode[1] =='numpadenter'):
-            self.popupContent.done()
-        elif (keycode[1] == 'escape'):     # abort entering a number, keep the old number
-            self.popupContent.textInput.text = ''    # clear text so it isn't converted to a number
-            self.popupContent.done()
-        return True     # always swallow keypresses since this is a modal dialog
+    
     
     def units(self):
         '''

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -640,8 +640,6 @@
 
 <TriangularCalibration>:
     testCutPosSlider:testCutPosSlider
-    triangleMeasure:triangleMeasure
-    unitsBtnT:unitsBtnT
     cutBtnT:cutBtnT
     enterValuesT:enterValuesT
     
@@ -669,19 +667,9 @@
                     cols: 1
                     size_hint_x: .8
                     Label:
-                    Label:
-                        text: "Measurement:"
-                    TextInput:
-                        id:triangleMeasure
-                        disabled: True
-                    Button:
-                        text: "MM"
-                        on_release: root.switchUnits()
-                        id: unitsBtnT
-                        disabled: True
                     Button:
                         text: "Enter Value"
-                        on_release: root.enterTestPaternValuesTriangular()
+                        on_release: root.enterDist()
                         id: enterValuesT
                         disabled: True
                     Button:


### PR DESCRIPTION
This PR adds touch support for entering the measured distance during the calibration process. It leaves in place the existing behaviors we have defined for when buttons are enabled and disabled, and preserves the 'sanity check' on numbers entered.

This pull request also moves the keyboard specific functions required to use the keyboard to enter numbers in the z-axis into the number popup and out of the z-axis popup so that the keyboard can be used also. This gives us a nice "Enter a number" widget which we can use in multiple places (like the quadrilateral popup which is going to get a similar overhaul!)

Here's what it looks like now:

![image](https://user-images.githubusercontent.com/9359447/34315310-dc80df42-e732-11e7-8d5a-c92cbd9ba282.png)

![image](https://user-images.githubusercontent.com/9359447/34315313-e6cb3f60-e732-11e7-84fe-260c7cf20e65.png)
