### PR TITLE
Clean up connectMenu.py and serialPort.py; use serial.tools.list_ports.comports()

### DIFF
--- a/Connection/serialPort.py
+++ b/Connection/serialPort.py
@@ -18,7 +18,7 @@ class SerialPort(MakesmithInitFuncs):
     '''
     
     
-    COMports = ListProperty(("Available Ports:", "None"))
+    # COMports = ListProperty(("Available Ports:", "None"))
     
     def __init__(self):
         '''
@@ -48,24 +48,7 @@ class SerialPort(MakesmithInitFuncs):
         '''
         self.data.config.set('Makesmith Settings', 'COMport', str(self.data.comport))
         self.data.config.write()
-    
-    def updatePorts(self, *args):
-        '''
         
-        Talks to the OS and determines which devices are available on which ports.
-        
-        '''
-        
-        portsList = ["Available Ports:"]
-        
-        for port in self.listSerialPorts():
-            portsList.append(port)
-        
-        if len(portsList) == 1:
-            portsList.append("None")
-        
-        self.COMports = portsList
-    
     '''
     
     Serial Connection Functions
@@ -85,43 +68,3 @@ class SerialPort(MakesmithInitFuncs):
             self.th.daemon = True
             self.th.start()
     
-    def listSerialPorts(self):
-        #Detects all the devices connected to the computer. Returns them as an array.
-        import glob
-        if sys.platform.startswith('win'):
-		list = serial.tools.list_ports.comports()
-		ports = []
-		for element in list:
-			ports.append(element.device)	
-
-        elif sys.platform.startswith('linux'):
-            # this is to exclude your current terminal "/dev/tty"
-            ports = glob.glob('/dev/tty[A-Za-z]*')
-
-        elif sys.platform.startswith('darwin'):
-            ports = glob.glob('/dev/tty.*')
-
-        else:
-            raise EnvironmentError('Unsupported platform')
-
-        result = []
-        for port in ports:
-            try:
-                s = serial.Serial(port)
-                s.close()
-                print ("Port " + port)
-                result.append(port)
-            except (OSError, serial.SerialException):
-                pass
-            except (ValueError):
-                print("Port find error")
-        return result
-    
-    def detectCOMports(self, *args):
-        x = []
-        
-        altPorts = self.listSerialPorts()
-        for z in altPorts:
-            x.append((z,z))
-        
-        self.comPorts = x

--- a/Connection/serialPort.py
+++ b/Connection/serialPort.py
@@ -5,6 +5,7 @@ from Connection.serialPortThread               import  SerialPortThread
 
 import sys
 import serial
+import serial.tools.list_ports
 import threading
 
 class SerialPort(MakesmithInitFuncs):
@@ -88,7 +89,10 @@ class SerialPort(MakesmithInitFuncs):
         #Detects all the devices connected to the computer. Returns them as an array.
         import glob
         if sys.platform.startswith('win'):
-            ports = ['COM' + str(i + 1) for i in range(256)]
+		list = serial.tools.list_ports.comports()
+		ports = []
+		for element in list:
+			ports.append(element.device)	
 
         elif sys.platform.startswith('linux'):
             # this is to exclude your current terminal "/dev/tty"
@@ -105,6 +109,7 @@ class SerialPort(MakesmithInitFuncs):
             try:
                 s = serial.Serial(port)
                 s.close()
+                print ("Port " + port)
                 result.append(port)
             except (OSError, serial.SerialException):
                 pass

--- a/UIElements/connectMenu.py
+++ b/UIElements/connectMenu.py
@@ -6,6 +6,7 @@ import sys
 import glob
 import serial
 import threading
+import serial.tools.list_ports
 
 class ConnectMenu(FloatLayout, MakesmithInitFuncs):
     
@@ -34,25 +35,47 @@ class ConnectMenu(FloatLayout, MakesmithInitFuncs):
             sysports = glob.glob('/dev/tty[A-Za-z]*')
             for port in sysports:
                 portsList.append(port)
+
         elif sys.platform.startswith('darwin'):
             sysports = glob.glob('/dev/tty.*')
             for port in sysports:
                 portsList.append(port)
-        else:
-        #  sys.platform.startswith('win'):
-            for port in self.data.serialPort.listSerialPorts():
+
+        elif sys.platform.startswith('win'):
+            for port in self.listSerialPorts():
                 portsList.append(port)
         
+        else:
+            raise EnvironmentError('Unsupported platform - can\'t find serial ports')
+
         if len(portsList) == 1:
             portsList.append("None")
         
         self.COMports = portsList
     
-    def detectCOMports(self, *args):
-        x = []
-        
-        altPorts = self.listSerialPorts()
-        for z in altPorts:
-            x.append((z,z))
-        
-        self.comPorts = x
+
+    def listSerialPorts(self):
+        #Detects all the devices connected to the computer. Returns them as an array.
+        # import glob
+        if sys.platform.startswith('win'):
+            list = serial.tools.list_ports.comports()
+            ports = []
+            for element in list:
+                ports.append(element.device)    
+
+        else:
+            raise EnvironmentError('Windows port search error')
+
+        result = []
+        for port in ports:
+            try:
+                s = serial.Serial(port)
+                s.close()
+                print ("Port " + port)
+                result.append(port)
+            except (OSError, serial.SerialException):
+                pass
+            except (ValueError):
+                print("Port find error")
+        return result
+    


### PR DESCRIPTION
There seem to be a number functions in connectMenu.py that are duplicated in serialPort.py but never used.
It looks like updatePorts(), and detectCOMports() could be removed from serialPort.py, and the 'win' portion of listSerialPorts() moved into connectMenu.py.
The 'linux/cygwin' and 'darwin' portions of connectMenu.updatePorts() are one-liners, the 'win' section needs the logic in listSerialPorts() - instead of making a list of 255 COM ports and testing each one, use serial.tools.list_ports.comports() to create a list of open COM ports

See discussion in issue #504 'listSerialPorts slow with bluetooth enabled'