### PR TITLE
Update frontPage.py to correct inches/mm conversion

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -142,11 +142,11 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
         if newUnits == "INCHES":
             self.data.gcode_queue.put('G20 ')
-            self.moveDistInput.text = str(float(self.moveDistInput.text)/MMTOINCHES)
+            self.moveDistInput.text = "{0:.2f}".format(float(self.moveDistInput.text)/MMTOINCHES)
             self.data.tolerance = 0.020
         else:
             self.data.gcode_queue.put('G21 ')
-            self.moveDistInput.text = str(float(self.moveDistInput.text)/INCHESTOMM)
+            self.moveDistInput.text = "{0:.2f}".format(float(self.moveDistInput.text)/INCHESTOMM)
             self.data.tolerance = 0.5
     
     def onIndexMove(self, callback, newIndex):

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -142,11 +142,11 @@ class FrontPage(Screen, MakesmithInitFuncs):
         
         if newUnits == "INCHES":
             self.data.gcode_queue.put('G20 ')
-            self.moveDistInput.text = str(float(self.moveDistInput.text)/25)
+            self.moveDistInput.text = str(float(self.moveDistInput.text)/MMTOINCHES)
             self.data.tolerance = 0.020
         else:
             self.data.gcode_queue.put('G21 ')
-            self.moveDistInput.text = str(float(self.moveDistInput.text)*25)
+            self.moveDistInput.text = str(float(self.moveDistInput.text)/INCHESTOMM)
             self.data.tolerance = 0.5
     
     def onIndexMove(self, callback, newIndex):


### PR DESCRIPTION
The code to convert from values on the screen from inches to mm (and vice versa) assumes used 1 in to 25 mm conversion factor.  It's more accurate to use the values defined just above in the code.

Just a little clean up.
