### PR TITLE
Switch pos indicator color with theme colors

### DIFF
--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -71,6 +71,8 @@ class Data(EventDispatcher):
     fontColor                                             =  StringProperty('[color=7a7a7a]')
     drawingColor                                          =  ObjectProperty([.47,.47,.47])
     iconPath                                              =  StringProperty('./Images/Icons/normal/')
+    posIndicatorColor                                     =  ObjectProperty([0,0,0])
+    targetInicatorColor                                   =  ObjectProperty([1,0,0])
     
     
     '''

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -40,8 +40,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
     
     def initialize(self):
         
-        self.targetIndicator.color   = (1,0,0)
-        self.positionIndicator.color = (0,0,0)
+        self.targetIndicator.color   = self.data.targetInicatorColor
+        self.positionIndicator.color = self.data.posIndicatorColor
         
         self.drawWorkspace()
 

--- a/main.py
+++ b/main.py
@@ -356,15 +356,19 @@ class GroundControlApp(App):
         self.data       =  Data()
         
         if self.config.get('Maslow Settings', 'colorScheme') == 'Light':
-            self.data.iconPath        = './Images/Icons/normal/'
-            self.data.fontColor       = '[color=7a7a7a]'
-            self.data.drawingColor    = [.47,.47,.47]
-            Window.clearcolor         = (1, 1, 1, 1)
+            self.data.iconPath               = './Images/Icons/normal/'
+            self.data.fontColor              = '[color=7a7a7a]'
+            self.data.drawingColor           = [.47,.47,.47]
+            Window.clearcolor                = (1, 1, 1, 1)
+            self.data.posIndicatorColor      =  [0,0,0]
+            self.data.targetInicatorColor    =  [1,0,0]
         elif self.config.get('Maslow Settings', 'colorScheme') == 'Dark':
-            self.data.iconPath        = './Images/Icons/highvis/'
-            self.data.fontColor       = '[color=000000]'
-            self.data.drawingColor    = [1,1,1]
-            Window.clearcolor         = (0, 0, 0, 1)
+            self.data.iconPath               = './Images/Icons/highvis/'
+            self.data.fontColor              = '[color=000000]'
+            self.data.drawingColor           = [1,1,1]
+            Window.clearcolor                = (0, 0, 0, 1)
+            self.data.posIndicatorColor      =  [1,1,1]
+            self.data.targetInicatorColor    =  [1,0,0]
         
         
         Window.maximize()


### PR DESCRIPTION
The position indicator color was not being updated with the change to the theme color.

This pull request adds fields to the data object to set the color of both the position and error indicators.

Fixes #530 