### PR TITLE
Fix for 529

### DIFF
--- a/UIElements/fileBrowser.py
+++ b/UIElements/fileBrowser.py
@@ -217,6 +217,7 @@ Builder.load_string('''
             root.selection) if root.multiselect else root.selection[0])) or ''
             hint_text: 'Filename'
             multiline: False
+            disabled: True
         Button:
             id: select_button
             size_hint_x: None


### PR DESCRIPTION
Disables the text entry box on the file open window which crashes GC if the input text string is not a valid file.

Still missing a fix for .ngc files not showing up in the preview.

Fixes #529 