### PR TITLE
Update the command to wipe the EEPROM

### DIFF
--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -4,7 +4,8 @@ from UIElements.scrollableTextPopup              import    ScrollableTextPopup
 from kivy.uix.popup                              import    Popup
 from UIElements.measureMachinePopup              import    MeasureMachinePopup
 from UIElements.calibrateLengthsPopup            import    CalibrateLengthsPopup
-from Simulation.simulationCanvas                 import SimulationCanvas
+from Simulation.simulationCanvas                 import    SimulationCanvas
+from kivy.clock                                  import    Clock
 import sys
 
 class Diagnostics(FloatLayout, MakesmithInitFuncs):
@@ -75,6 +76,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
     
     def wipeEEPROM(self):
         self.data.gcode_queue.put("$RST=* ")
+        Clock.schedule_once(self.data.pushSettings, 6)
         self.parentWidget.close()
     
     def measureMachine(self):

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -74,7 +74,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         self.parentWidget.close()
     
     def wipeEEPROM(self):
-        self.data.gcode_queue.put("B07 ")
+        self.data.gcode_queue.put("$RST=* ")
         self.parentWidget.close()
     
     def measureMachine(self):

--- a/main.py
+++ b/main.py
@@ -496,7 +496,6 @@ class GroundControlApp(App):
     
     def push_settings_to_machine(self, *args):
         
-        
         #Push motor configuration settings to machine
         
         if self.data.connectionStatus != 1:


### PR DESCRIPTION
Updates to use the new command to wipe the EEPROM. This uses the maximum option of wiping the entire 4k EEPROM

Fixes #532