### PR TITLE
Fix missing data link in go to line popup

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -410,7 +410,7 @@ class FrontPage(Screen, MakesmithInitFuncs):
 
     def gotoLinePopup(self):
         
-        self.popupContent = TouchNumberInput(done=self.dismiss_gotoLinePopup)
+        self.popupContent = TouchNumberInput(done=self.dismiss_gotoLinePopup, data=self.data)
         self._popup = Popup(title="Go to gcode line", content=self.popupContent,
                             size_hint=(0.9, 0.9))
         self._popup.open()


### PR DESCRIPTION
Fixes the missing link to data which was causing GC to crash when entering a line number to jump to

Fixes #539