### PR TITLE
Disable command to zero the axes in Step1 'Begin' button

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -158,7 +158,7 @@ class MeasureMachinePopup(GridLayout):
         each sprocket to 12:00
 
         '''
-        self.data.gcode_queue.put("B06 L0 R0 ");
+        # self.data.gcode_queue.put("B06 L0 R0 ");
         self.carousel.load_next()
             
     def extendLeft(self, dist):


### PR DESCRIPTION
I think the issue I was seeing was caused by the 'Begin' button in Step1 - it executes gcode "B06 L0 R0" which tells both axes that they are at the first link of the chain. There is a comment "This prevents strange behavior when rotating each sprocket to 12:00".
With the present code, clicking this button clobbers your chain calibration whether that was what you intended or not.
 I believe recent changes to kinematics and the chain calibration procedure make this 'Begin' button behaviour unnecessary.