### PR TITLE
Don't Add Extra Space onto Quick Commands

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -131,7 +131,7 @@ class SerialPortThread(MakesmithInitFuncs):
                 
                 #send any emergency instructions to the machine if there are any
                 if self.data.quick_queue.empty() != True:
-                    command = self.data.quick_queue.get_nowait() + " "
+                    command = self.data.quick_queue.get_nowait()
                     self._write(command, True)
                 
                 #send regular instructions to the machine if there are any


### PR DESCRIPTION
I don't think they are needed for regular commands either, but
they only add one more thing that has to be disposed of when
processing a quick command in the firmware.