### PR TITLE
Sleep Serial Thread for Massive Decrease in CPU Usage

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -168,4 +168,7 @@ class SerialPortThread(MakesmithInitFuncs):
                     self.data.connectionStatus = 0
                     self.serialInstance.close()
                     return
+                
+                # Sleep between passes to save CPU
+                time.sleep(.001)
                     


### PR DESCRIPTION
Not sure how we missed this, but I noticed that my laptop sounded awfully loud.  Upon closer inspection python was eating up a full core.  It looks like the issue is we just needed a slight sleep in the SerialRead thread.  I just picked a millisecond, which took my CPU time down to nearly zero.  We could increase this if others with slower machines are noticing issues.

I wonder if this will let me increase my Kivy framerate?