### PR TITLE
Update settings on machine when z-axis is turned on

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -280,6 +280,7 @@ class MeasureMachinePopup(GridLayout):
         '''
         self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
         self.data.config.write()
+        self.data.pushSettings()
 
     def pullChainTight(self):
         #pull the left chain tight


### PR DESCRIPTION
This change pushes the changed settings to the machine when the z-axis switch is touched during the calibration process

Fixes #556