### PR TITLE
Simulation-use-current-kinematics-setting

### DIFF
--- a/Simulation/simulationCanvas.py
+++ b/Simulation/simulationCanvas.py
@@ -25,6 +25,7 @@ class SimulationCanvas(GridLayout):
 
     correctKinematics   = Kinematics()
     distortedKinematics = Kinematics()
+    kinematicsType      = 'Quadrilateral'
     
     isQuadKinematics    = BooleanProperty(True)
 
@@ -43,8 +44,9 @@ class SimulationCanvas(GridLayout):
         
         Clock.schedule_once(self.moveToCenter, 3)
         
-        self.kinematicsSelect.text = "Quadrilateral"
-        
+        #start with our current kinematics type
+        self.kinematicsSelect.text = self.data.config.get('Advanced Settings', 'kinematicsType')
+          
         self.recompute()
     
     def moveToCenter(self, *args):


### PR DESCRIPTION
Start the simulation using the kinematics type found in groundcontrol.ini. Allow the use of the other type for simulation but do not change the .ini file setting.