### PR TITLE
Properly Treat Error Responses as Equivalent to ok

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -119,7 +119,7 @@ class SerialPortThread(MakesmithInitFuncs):
                     pass
                 
                 #Check if a line has been completed
-                if lineFromMachine == "ok\r\n":
+                if lineFromMachine == "ok\r\n" or (len(lineFromMachine) >= 6 and lineFromMachine[0:6] == "error:"):
                     self.machineIsReadyForData = True
                     if bool(self.lengthOfLastLineStack) is True:                                     #if we've sent lines to the machine
                         self.bufferSpace = self.bufferSpace + self.lengthOfLastLineStack.pop()    #free up that space in the buffer


### PR DESCRIPTION
This is a small fix.  The Grbl spec will send error: xxxx responses with no ok response.  This tells GC to properly move on to the next message when such responses are received.