### PR TITLE
Make sure the gcode for testing folder is available

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,6 +1,5 @@
 python -m PyInstaller --clean --win-private-assemblies --onefile GroundControl.spec
 rmdir build /s /Q
-rmdir .\dist\GroundControl\gcodeForTesting /s /Q
 rmdir .\dist\GroundControl\.git /s /Q
 rmdir .\dist\GroundControl\build /s /Q
 rmdir .\dist\GroundControl\Connection /s /Q
@@ -9,6 +8,7 @@ rmdir .\dist\GroundControl\Documentation /s /Q
 rmdir .\dist\GroundControl\Simulation /s /Q
 rmdir .\dist\GroundControl\UIElements /s /Q
 robocopy /E ./Documentation ./dist/GroundControl/Documentation
+robocopy /E ./gcodeForTesting ./dist/gcodeForTesting
 copy "./Launch Ground Control.bat" "./dist/Launch Ground Control.bat"
 robocopy /E ./dist ./GroundControl-Windows.Portable.v0.
 rmdir .\dist /s /Q


### PR DESCRIPTION
This adds the gcodeForTesting older to the ground control build script so that it is available to run the test script

Fixes #588