### PR TITLE
Use normal z-axis popup during calibration

### DIFF
--- a/UIElements/adjustZCalibrationDepth.py
+++ b/UIElements/adjustZCalibrationDepth.py
@@ -1,8 +1,8 @@
 from   kivy.uix.widget                    import   Widget
 from   kivy.properties                    import   ObjectProperty
-from   kivy.properties                    import   StringProperty
 from   UIElements.touchNumberInput        import   TouchNumberInput
 from   kivy.uix.popup                     import   Popup
+from UIElements.zAxisPopupContent              import ZAxisPopupContent
 
 class AdjustZCalibrationDepth(Widget):
     '''
@@ -11,6 +11,7 @@ class AdjustZCalibrationDepth(Widget):
     
     '''
     data                         =  ObjectProperty(None) #linked externally
+    zStepSizeVal                 =  .1                   #The default movement size for the z-axis
     
     def on_enter(self):
         '''
@@ -20,27 +21,11 @@ class AdjustZCalibrationDepth(Widget):
         '''
         if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
             self.zAxisActiveSwitch.active = True
+            self.openZPopupBtn.disabled        = False
         else:
             self.zAxisActiveSwitch.active = False
+            self.openZPopupBtn.disabled        = True
     
-    def moveZ(self, dist):
-        '''
-
-        Move the z-axis the specified distance
-
-        '''
-        self.data.units = "MM"
-        self.data.gcode_queue.put("G21 ")
-        self.data.gcode_queue.put("G91 G00 Z" + str(dist) + " G90 ")
-
-    def zeroZ(self):
-        '''
-
-        Define the z-axis to be currently at height 0
-
-        '''
-        self.data.gcode_queue.put("G10 Z0 ")
-        self.carousel.load_next()
     
     def enableZaxis(self, *args):
         '''
@@ -51,3 +36,38 @@ class AdjustZCalibrationDepth(Widget):
         self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
         self.data.config.write()
         self.data.pushSettings()
+        
+        #enable and disable the button to open the z-axis popup
+        if self.zAxisActiveSwitch.active == True:
+            self.openZPopupBtn.disabled        = False
+        else:
+            self.openZPopupBtn.disabled        = True
+    
+    def zAxisPopup(self):
+        self.popupContent      = ZAxisPopupContent(done=self.dismissZAxisPopup)
+        self.popupContent.data = self.data
+        self.popupContent.initialize(self.zStepSizeVal)
+        self._zpopup = Popup(title="Z-Axis", content=self.popupContent,
+                            size_hint=(0.5, 0.5))
+        self._zpopup.open()
+    
+    def dismissZAxisPopup(self):
+        '''
+        
+        Close The Z-Axis Pop-up
+        
+        '''
+        try:
+            self.zStepSizeVal = float(self.popupContent.distBtn.text)
+        except:
+            pass
+        self._zpopup.dismiss()
+    
+    def zeroZ(self):
+        '''
+
+        Define the z-axis to be currently at height 0
+
+        '''
+        self.data.gcode_queue.put("G10 Z0 ")
+        self.carousel.load_next()

--- a/UIElements/adjustZCalibrationDepth.py
+++ b/UIElements/adjustZCalibrationDepth.py
@@ -1,0 +1,53 @@
+from   kivy.uix.widget                    import   Widget
+from   kivy.properties                    import   ObjectProperty
+from   kivy.properties                    import   StringProperty
+from   UIElements.touchNumberInput        import   TouchNumberInput
+from   kivy.uix.popup                     import   Popup
+
+class AdjustZCalibrationDepth(Widget):
+    '''
+    
+    Provides a standard interface for running the calibration test pattern for triangular kinematics 
+    
+    '''
+    data                         =  ObjectProperty(None) #linked externally
+    
+    def on_enter(self):
+        '''
+        
+        Called when the calibration process gets to this step
+        
+        '''
+        if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
+            self.zAxisActiveSwitch.active = True
+        else:
+            self.zAxisActiveSwitch.active = False
+    
+    def moveZ(self, dist):
+        '''
+
+        Move the z-axis the specified distance
+
+        '''
+        self.data.units = "MM"
+        self.data.gcode_queue.put("G21 ")
+        self.data.gcode_queue.put("G91 G00 Z" + str(dist) + " G90 ")
+
+    def zeroZ(self):
+        '''
+
+        Define the z-axis to be currently at height 0
+
+        '''
+        self.data.gcode_queue.put("G10 Z0 ")
+        self.carousel.load_next()
+    
+    def enableZaxis(self, *args):
+        '''
+
+        Triggered when the switch to enable the z-axis is touched
+
+        '''
+        self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
+        self.data.config.write()
+        self.data.pushSettings()

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -8,6 +8,7 @@ from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   UIElements.touchNumberInput               import   TouchNumberInput
 from   UIElements.triangularCalibration          import   TriangularCalibration
+from   UIElements.adjustZCalibrationDepth        import   AdjustZCalibrationDepth
 from   kivy.uix.popup                            import   Popup
 import global_variables
 
@@ -32,7 +33,10 @@ class MeasureMachinePopup(GridLayout):
         self.measureOutChains.data          =  data
         self.measureOutChains.carousel      =  self.carousel
         self.measureOutChains.text          =  "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
-
+        
+        self.adjustZStep.data               =  data
+        self.adjustZStep.carousel           =  self.carousel
+        
         self.triangularCalibration.data          =  data
         self.triangularCalibration.carousel      =  self.carousel
         triangularTestCutText = "The cuts in the corners will be about\n254 mm/10 inches from the work area edges.\n\n"
@@ -70,7 +74,15 @@ class MeasureMachinePopup(GridLayout):
             self.carousel.load_next()
 
     def slideJustChanged(self):
-
+        '''
+        
+        Runs when the slide has just been changed
+        
+        '''
+        
+        print self.carousel.slides
+        #self.carousel.slides[self.carousel.index].on_enter()
+        
         if self.carousel.index == 0:
             #begin notes
             self.goBackBtn.disabled = True
@@ -107,10 +119,7 @@ class MeasureMachinePopup(GridLayout):
 
         if self.carousel.index == 7:
             #set up z-axis
-            if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
-                self.zAxisActiveSwitch.active = True
-            else:
-                self.zAxisActiveSwitch.active = False
+            self.adjustZStep.on_enter()
             self.stepText = "Step 8 of 10"
 
         if self.carousel.index == 8:
@@ -278,16 +287,6 @@ class MeasureMachinePopup(GridLayout):
         print "calibrating"
         self.data.gcode_queue.put("B02 ")
 
-    def enableZaxis(self, *args):
-        '''
-
-        Triggered when the switch to enable the z-axis is touched
-
-        '''
-        self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
-        self.data.config.write()
-        self.data.pushSettings()
-
     def pullChainTight(self):
         #pull the left chain tight
         self.data.gcode_queue.put("B11 S50 T3 ")
@@ -411,21 +410,4 @@ class MeasureMachinePopup(GridLayout):
         else:
             self.unitsBtn.text = 'MM'
 
-    def moveZ(self, dist):
-        '''
-
-        Move the z-axis the specified distance
-
-        '''
-        self.data.units = "MM"
-        self.data.gcode_queue.put("G21 ")
-        self.data.gcode_queue.put("G91 G00 Z" + str(dist) + " G90 ")
-
-    def zeroZ(self):
-        '''
-
-        Define the z-axis to be currently at height 0
-
-        '''
-        self.data.gcode_queue.put("G10 Z0 ")
-        self.carousel.load_next()
+    

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -696,6 +696,50 @@
                 on_release: root.stopCut()
             Label:
 
+<AdjustZCalibrationDepth>:
+    zAxisActiveSwitch:zAxisActiveSwitch
+    GridLayout:
+        cols: 2
+        width: root.width
+        height: root.height
+        GridLayout:
+            cols: 1
+            size_hint_x: leftCol
+            Label:
+                text: "Next, we are going to define the home position for the z-axis\n\nIf you have an automatic z-axis installed use the buttons to enable it and adjust the z-axis until the router bit\nbarely touches the surface of the wood. Then press Define Zero\n\nIf you do not have the z-axis installed, adjust your router until the router bit just barely\ntouches the surface of the wood, then press Define Zero"
+                size_hint_x: leftCol
+            GridLayout:
+                cols: 2
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Set Z Height.jpg"
+        GridLayout:
+            cols: 1
+            size_hint_x: rightCol
+            Label:
+            GridLayout:
+                cols: 2
+                Label:
+                    text: 'Enable\nAutomatic Z-Axis:'
+                Switch:
+                    on_active: root.enableZaxis()
+                    id: zAxisActiveSwitch
+            Button:
+                text: 'Raise Z-Axis 1mm'
+                on_release: root.moveZ(1)
+            Button:
+                text: 'Raise Z-Axis .1mm'
+                on_release: root.moveZ(.1)
+            Button:
+                text: 'Lower Z-Axis 1mm'
+                on_release: root.moveZ(-1)
+            Button:
+                text: 'Lower Z-Axis .1mm'
+                on_release: root.moveZ(-.1)
+            Button:
+                text: 'Define Zero'
+                on_release: root.zeroZ()
+            Label:
+                
 <SetSprocketsVertical>:
     #Set sprockets to 12 o'clock
     GridLayout:
@@ -820,11 +864,11 @@
     vertMeasure:vertMeasure
     unitsBtn:unitsBtn
     enterValues:enterValues
-    zAxisActiveSwitch:zAxisActiveSwitch
     setSprocketsVertical:setSprocketsVertical
     measureOutChains:measureOutChains
     triangularCalibration:triangularCalibration
     finishText:finishText
+    adjustZStep:adjustZStep
 
     cols: 1
     size: root.size
@@ -1015,44 +1059,9 @@
                 id: measureOutChains
         #set z-axis depth
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                size_hint_x: leftCol
-                Label:
-                    text: "Next, we are going to define the home position for the z-axis\n\nIf you have an automatic z-axis installed use the buttons to enable it and adjust the z-axis until the router bit\nbarely touches the surface of the wood. Then press Define Zero\n\nIf you do not have the z-axis installed, adjust your router until the router bit just barely\ntouches the surface of the wood, then press Define Zero"
-                    size_hint_x: leftCol
-                GridLayout:
-                    cols: 2
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Set Z Height.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                GridLayout:
-                    cols: 2
-                    Label:
-                        text: 'Enable\nAutomatic Z-Axis:'
-                    Switch:
-                        on_active: root.enableZaxis()
-                        id: zAxisActiveSwitch
-                Button:
-                    text: 'Raise Z-Axis 1mm'
-                    on_release: root.moveZ(1)
-                Button:
-                    text: 'Raise Z-Axis .1mm'
-                    on_release: root.moveZ(.1)
-                Button:
-                    text: 'Lower Z-Axis 1mm'
-                    on_release: root.moveZ(-1)
-                Button:
-                    text: 'Lower Z-Axis .1mm'
-                    on_release: root.moveZ(-.1)
-                Button:
-                    text: 'Define Zero'
-                    on_release: root.zeroZ()
-                Label:
+            cols: 1
+            AdjustZCalibrationDepth:
+                id: adjustZStep
         #choose kinematics type
         GridLayout:
             cols: 2

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -698,6 +698,7 @@
 
 <AdjustZCalibrationDepth>:
     zAxisActiveSwitch:zAxisActiveSwitch
+    openZPopupBtn:openZPopupBtn
     GridLayout:
         cols: 2
         width: root.width
@@ -724,17 +725,10 @@
                     on_active: root.enableZaxis()
                     id: zAxisActiveSwitch
             Button:
-                text: 'Raise Z-Axis 1mm'
-                on_release: root.moveZ(1)
-            Button:
-                text: 'Raise Z-Axis .1mm'
-                on_release: root.moveZ(.1)
-            Button:
-                text: 'Lower Z-Axis 1mm'
-                on_release: root.moveZ(-1)
-            Button:
-                text: 'Lower Z-Axis .1mm'
-                on_release: root.moveZ(-.1)
+                text: "Adjust Z-Axis"
+                on_release: root.zAxisPopup()
+                disabled:True
+                id: openZPopupBtn
             Button:
                 text: 'Define Zero'
                 on_release: root.zeroZ()


### PR DESCRIPTION
This PR starts to address the feature request in #349 which asks to use the normal machine controls as much as possible during the calibration process. 

The "Adjust the z-axis to depth zero" step will now use the same controls as the regular interface.

Here is what the step looks like:

![image](https://user-images.githubusercontent.com/9359447/35705614-d52c2464-0757-11e8-96a1-216e8fe8894d.png)

And here is what the popup looks like:

![image](https://user-images.githubusercontent.com/9359447/35705629-e43564ca-0757-11e8-9e56-d0e7ffd337d3.png)

The button to open the popup is disabled if the z-axis is not installed:

![image](https://user-images.githubusercontent.com/9359447/35705656-f358d6d0-0757-11e8-809e-32dd0491206e.png)

