### PR TITLE
Make it possible to extend chain by an arbitrary length

### DIFF
--- a/UIElements/adjustZCalibrationDepth.py
+++ b/UIElements/adjustZCalibrationDepth.py
@@ -1,8 +1,8 @@
 from   kivy.uix.widget                    import   Widget
 from   kivy.properties                    import   ObjectProperty
-from   kivy.properties                    import   StringProperty
 from   UIElements.touchNumberInput        import   TouchNumberInput
 from   kivy.uix.popup                     import   Popup
+from UIElements.zAxisPopupContent              import ZAxisPopupContent
 
 class AdjustZCalibrationDepth(Widget):
     '''
@@ -11,6 +11,7 @@ class AdjustZCalibrationDepth(Widget):
     
     '''
     data                         =  ObjectProperty(None) #linked externally
+    zStepSizeVal                 =  .1                   #The default movement size for the z-axis
     
     def on_enter(self):
         '''
@@ -20,27 +21,11 @@ class AdjustZCalibrationDepth(Widget):
         '''
         if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
             self.zAxisActiveSwitch.active = True
+            self.openZPopupBtn.disabled        = False
         else:
             self.zAxisActiveSwitch.active = False
+            self.openZPopupBtn.disabled        = True
     
-    def moveZ(self, dist):
-        '''
-
-        Move the z-axis the specified distance
-
-        '''
-        self.data.units = "MM"
-        self.data.gcode_queue.put("G21 ")
-        self.data.gcode_queue.put("G91 G00 Z" + str(dist) + " G90 ")
-
-    def zeroZ(self):
-        '''
-
-        Define the z-axis to be currently at height 0
-
-        '''
-        self.data.gcode_queue.put("G10 Z0 ")
-        self.carousel.load_next()
     
     def enableZaxis(self, *args):
         '''
@@ -51,3 +36,38 @@ class AdjustZCalibrationDepth(Widget):
         self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
         self.data.config.write()
         self.data.pushSettings()
+        
+        #enable and disable the button to open the z-axis popup
+        if self.zAxisActiveSwitch.active == True:
+            self.openZPopupBtn.disabled        = False
+        else:
+            self.openZPopupBtn.disabled        = True
+    
+    def zAxisPopup(self):
+        self.popupContent      = ZAxisPopupContent(done=self.dismissZAxisPopup)
+        self.popupContent.data = self.data
+        self.popupContent.initialize(self.zStepSizeVal)
+        self._zpopup = Popup(title="Z-Axis", content=self.popupContent,
+                            size_hint=(0.5, 0.5))
+        self._zpopup.open()
+    
+    def dismissZAxisPopup(self):
+        '''
+        
+        Close The Z-Axis Pop-up
+        
+        '''
+        try:
+            self.zStepSizeVal = float(self.popupContent.distBtn.text)
+        except:
+            pass
+        self._zpopup.dismiss()
+    
+    def zeroZ(self):
+        '''
+
+        Define the z-axis to be currently at height 0
+
+        '''
+        self.data.gcode_queue.put("G10 Z0 ")
+        self.carousel.load_next()

--- a/UIElements/adjustZCalibrationDepth.py
+++ b/UIElements/adjustZCalibrationDepth.py
@@ -1,0 +1,53 @@
+from   kivy.uix.widget                    import   Widget
+from   kivy.properties                    import   ObjectProperty
+from   kivy.properties                    import   StringProperty
+from   UIElements.touchNumberInput        import   TouchNumberInput
+from   kivy.uix.popup                     import   Popup
+
+class AdjustZCalibrationDepth(Widget):
+    '''
+    
+    Provides a standard interface for running the calibration test pattern for triangular kinematics 
+    
+    '''
+    data                         =  ObjectProperty(None) #linked externally
+    
+    def on_enter(self):
+        '''
+        
+        Called when the calibration process gets to this step
+        
+        '''
+        if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
+            self.zAxisActiveSwitch.active = True
+        else:
+            self.zAxisActiveSwitch.active = False
+    
+    def moveZ(self, dist):
+        '''
+
+        Move the z-axis the specified distance
+
+        '''
+        self.data.units = "MM"
+        self.data.gcode_queue.put("G21 ")
+        self.data.gcode_queue.put("G91 G00 Z" + str(dist) + " G90 ")
+
+    def zeroZ(self):
+        '''
+
+        Define the z-axis to be currently at height 0
+
+        '''
+        self.data.gcode_queue.put("G10 Z0 ")
+        self.carousel.load_next()
+    
+    def enableZaxis(self, *args):
+        '''
+
+        Triggered when the switch to enable the z-axis is touched
+
+        '''
+        self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
+        self.data.config.write()
+        self.data.pushSettings()

--- a/UIElements/measureDistBetweenMotors.py
+++ b/UIElements/measureDistBetweenMotors.py
@@ -32,9 +32,9 @@ class MeasureDistBetweenMotors(Widget):
             self._popup.bind(on_dismiss=self.ondismiss_popup)
     
     def ondismiss_popup(self, event):
-       if global_variables._keyboard:
+        if global_variables._keyboard:
            global_variables._keyboard.unbind(on_key_down=self.keydown_popup)
-    
+        
     def keydown_popup(self, keyboard, keycode, text, modifiers):
         if (keycode[1] == '0') or (keycode[1] =='numpad0'):
             self.popupContent.addText('0')
@@ -70,7 +70,8 @@ class MeasureDistBetweenMotors(Widget):
     def dismiss_popup(self):
         try:
             tempfloat = float(self.popupContent.textInput.text)
-            self.targetWidget.text = "Dist: " + str(tempfloat) + " " + self.data.units  # Update displayed text using standard numeric format
+            self.targetWidget.text = str(tempfloat)  # Update displayed text using standard numeric format
+            #self.distText.text = "Dist (" + self.data.units + "):"
         except:
             pass  # If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()
@@ -79,6 +80,18 @@ class MeasureDistBetweenMotors(Widget):
         self.data.quick_queue.put("!")
         with self.data.gcode_queue.mutex:
             self.data.gcode_queue.queue.clear()
+    
+    def extend(self):
+        dist = float(self.distToMove.text)
+        self.data.gcode_queue.put("G91 ")
+        self.data.gcode_queue.put("B09 L" + str(dist) + " ")
+        self.data.gcode_queue.put("G90 ")
+    
+    def retract(self):
+        dist = float(self.distToMove.text)
+        self.data.gcode_queue.put("G91 ")
+        self.data.gcode_queue.put("B09 L" + str(-1*dist) + " ")
+        self.data.gcode_queue.put("G90 ")
     
     def measureLeft(self):
         self.data.gcode_queue.put("B10 L")

--- a/UIElements/measureDistBetweenMotors.py
+++ b/UIElements/measureDistBetweenMotors.py
@@ -24,7 +24,7 @@ class MeasureDistBetweenMotors(Widget):
         self.targetWidget = target
 
         self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
-        self._popup = Popup(title="Number of links", content=self.popupContent,
+        self._popup = Popup(title="Set distance to move chain", content=self.popupContent,
                             size_hint=(0.9, 0.9))
         self._popup.open()
         if global_variables._keyboard:

--- a/UIElements/measureDistBetweenMotors.py
+++ b/UIElements/measureDistBetweenMotors.py
@@ -1,0 +1,88 @@
+from   kivy.uix.widget                    import   Widget
+from   kivy.properties                    import   ObjectProperty
+from   UIElements.touchNumberInput        import   TouchNumberInput
+from   kivy.uix.popup                     import   Popup
+import global_variables
+
+class MeasureDistBetweenMotors(Widget):
+    '''
+    
+    Provides a standard interface for measuring the distance between the motors. Assumes that both motors are in position zero at the begining
+    
+    '''
+    data                         =  ObjectProperty(None) #linked externally
+    
+    def on_enter(self):
+        '''
+        
+        Called when the calibration process gets to this step
+        
+        '''
+        pass
+    
+    def textInputPopup(self, target):
+        self.targetWidget = target
+
+        self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
+        self._popup = Popup(title="Number of links", content=self.popupContent,
+                            size_hint=(0.9, 0.9))
+        self._popup.open()
+        if global_variables._keyboard:
+            global_variables._keyboard.bind(on_key_down=self.keydown_popup)
+            self._popup.bind(on_dismiss=self.ondismiss_popup)
+    
+    def ondismiss_popup(self, event):
+       if global_variables._keyboard:
+           global_variables._keyboard.unbind(on_key_down=self.keydown_popup)
+    
+    def keydown_popup(self, keyboard, keycode, text, modifiers):
+        if (keycode[1] == '0') or (keycode[1] =='numpad0'):
+            self.popupContent.addText('0')
+        elif (keycode[1] == '1') or (keycode[1] =='numpad1'):
+            self.popupContent.addText('1')
+        elif (keycode[1] == '2') or (keycode[1] =='numpad2'):
+            self.popupContent.addText('2')
+        elif (keycode[1] == '3') or (keycode[1] =='numpad3'):
+            self.popupContent.addText('3')
+        elif (keycode[1] == '4') or (keycode[1] =='numpad4'):
+            self.popupContent.addText('4')
+        elif (keycode[1] == '5') or (keycode[1] =='numpad5'):
+            self.popupContent.addText('5')
+        elif (keycode[1] == '6') or (keycode[1] =='numpad6'):
+            self.popupContent.addText('6')
+        elif (keycode[1] == '7') or (keycode[1] =='numpad7'):
+            self.popupContent.addText('7')
+        elif (keycode[1] == '8') or (keycode[1] =='numpad8'):
+            self.popupContent.addText('8')
+        elif (keycode[1] == '9') or (keycode[1] =='numpad9'):
+            self.popupContent.addText('9')
+        elif (keycode[1] == '.') or (keycode[1] =='numpaddecimal'):
+            self.popupContent.addText('.')
+        elif (keycode[1] == 'backspace'):
+            self.popupContent.textInput.text = self.popupContent.textInput.text[:-1]
+        elif (keycode[1] == 'enter') or (keycode[1] =='numpadenter'):
+            self.popupContent.done()
+        elif (keycode[1] == 'escape'):     # abort entering a number, keep the old number
+            self.popupContent.textInput.text = ''    # clear text so it isn't converted to a number
+            self.popupContent.done()
+        return True     # always swallow keypresses since this is a modal dialog
+    
+    def dismiss_popup(self):
+        try:
+            tempfloat = float(self.popupContent.textInput.text)
+            self.targetWidget.text = "Dist: " + str(tempfloat) + " " + self.data.units  # Update displayed text using standard numeric format
+        except:
+            pass  # If what was entered cannot be converted to a number, leave the value the same
+        self._popup.dismiss()
+    
+    def stopCut(self):
+        self.data.quick_queue.put("!")
+        with self.data.gcode_queue.mutex:
+            self.data.gcode_queue.queue.clear()
+    
+    def measureLeft(self):
+        self.data.gcode_queue.put("B10 L")
+    
+    def pullChainTight(self):
+        #pull the left chain tight
+        self.data.gcode_queue.put("B11 S50 T3 ")

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -9,6 +9,7 @@ from   kivy.properties                           import   StringProperty
 from   UIElements.touchNumberInput               import   TouchNumberInput
 from   UIElements.triangularCalibration          import   TriangularCalibration
 from   UIElements.adjustZCalibrationDepth        import   AdjustZCalibrationDepth
+from   UIElements.measureDistBetweenMotors       import   MeasureDistBetweenMotors
 from   kivy.uix.popup                            import   Popup
 import global_variables
 
@@ -36,6 +37,9 @@ class MeasureMachinePopup(GridLayout):
         
         self.adjustZStep.data               =  data
         self.adjustZStep.carousel           =  self.carousel
+        
+        self.measureMotorDist.data          =  data
+        self.measureMotorDist.carousel      =  self.carousel
         
         self.triangularCalibration.data          =  data
         self.triangularCalibration.carousel      =  self.carousel
@@ -79,9 +83,6 @@ class MeasureMachinePopup(GridLayout):
         Runs when the slide has just been changed
         
         '''
-        
-        print self.carousel.slides
-        #self.carousel.slides[self.carousel.index].on_enter()
         
         if self.carousel.index == 0:
             #begin notes
@@ -286,10 +287,6 @@ class MeasureMachinePopup(GridLayout):
     def calibrateChainLengths(self):
         print "calibrating"
         self.data.gcode_queue.put("B02 ")
-
-    def pullChainTight(self):
-        #pull the left chain tight
-        self.data.gcode_queue.put("B11 S50 T3 ")
 
     def updateReviewValuesText(self, *args):
         '''

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -8,6 +8,7 @@ from   kivy.properties                           import   ObjectProperty
 from   kivy.properties                           import   StringProperty
 from   UIElements.touchNumberInput               import   TouchNumberInput
 from   UIElements.triangularCalibration          import   TriangularCalibration
+from   UIElements.adjustZCalibrationDepth        import   AdjustZCalibrationDepth
 from   kivy.uix.popup                            import   Popup
 import global_variables
 
@@ -32,7 +33,10 @@ class MeasureMachinePopup(GridLayout):
         self.measureOutChains.data          =  data
         self.measureOutChains.carousel      =  self.carousel
         self.measureOutChains.text          =  "Now we are going to measure out the chains and reattach the sled\n\nHook the first link of the right chain on the vertical tooth of the right sprocket\n as shown in the picture below\n\nThe left chain does not need to be moved, it can be left partly extended\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
-
+        
+        self.adjustZStep.data               =  data
+        self.adjustZStep.carousel           =  self.carousel
+        
         self.triangularCalibration.data          =  data
         self.triangularCalibration.carousel      =  self.carousel
         triangularTestCutText = "The cuts in the corners will be about\n254 mm/10 inches from the work area edges.\n\n"
@@ -70,7 +74,15 @@ class MeasureMachinePopup(GridLayout):
             self.carousel.load_next()
 
     def slideJustChanged(self):
-
+        '''
+        
+        Runs when the slide has just been changed
+        
+        '''
+        
+        print self.carousel.slides
+        #self.carousel.slides[self.carousel.index].on_enter()
+        
         if self.carousel.index == 0:
             #begin notes
             self.goBackBtn.disabled = True
@@ -107,10 +119,7 @@ class MeasureMachinePopup(GridLayout):
 
         if self.carousel.index == 7:
             #set up z-axis
-            if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
-                self.zAxisActiveSwitch.active = True
-            else:
-                self.zAxisActiveSwitch.active = False
+            self.adjustZStep.on_enter()
             self.stepText = "Step 8 of 10"
 
         if self.carousel.index == 8:
@@ -278,16 +287,6 @@ class MeasureMachinePopup(GridLayout):
         print "calibrating"
         self.data.gcode_queue.put("B02 ")
 
-    def enableZaxis(self, *args):
-        '''
-
-        Triggered when the switch to enable the z-axis is touched
-
-        '''
-        self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
-        self.data.config.write()
-        self.data.pushSettings()
-
     def pullChainTight(self):
         #pull the left chain tight
         self.data.gcode_queue.put("B11 S50 T3 ")
@@ -411,21 +410,4 @@ class MeasureMachinePopup(GridLayout):
         else:
             self.unitsBtn.text = 'MM'
 
-    def moveZ(self, dist):
-        '''
-
-        Move the z-axis the specified distance
-
-        '''
-        self.data.units = "MM"
-        self.data.gcode_queue.put("G21 ")
-        self.data.gcode_queue.put("G91 G00 Z" + str(dist) + " G90 ")
-
-    def zeroZ(self):
-        '''
-
-        Define the z-axis to be currently at height 0
-
-        '''
-        self.data.gcode_queue.put("G10 Z0 ")
-        self.carousel.load_next()
+    

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -696,6 +696,50 @@
                 on_release: root.stopCut()
             Label:
 
+<AdjustZCalibrationDepth>:
+    zAxisActiveSwitch:zAxisActiveSwitch
+    GridLayout:
+        cols: 2
+        width: root.width
+        height: root.height
+        GridLayout:
+            cols: 1
+            size_hint_x: leftCol
+            Label:
+                text: "Next, we are going to define the home position for the z-axis\n\nIf you have an automatic z-axis installed use the buttons to enable it and adjust the z-axis until the router bit\nbarely touches the surface of the wood. Then press Define Zero\n\nIf you do not have the z-axis installed, adjust your router until the router bit just barely\ntouches the surface of the wood, then press Define Zero"
+                size_hint_x: leftCol
+            GridLayout:
+                cols: 2
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Set Z Height.jpg"
+        GridLayout:
+            cols: 1
+            size_hint_x: rightCol
+            Label:
+            GridLayout:
+                cols: 2
+                Label:
+                    text: 'Enable\nAutomatic Z-Axis:'
+                Switch:
+                    on_active: root.enableZaxis()
+                    id: zAxisActiveSwitch
+            Button:
+                text: 'Raise Z-Axis 1mm'
+                on_release: root.moveZ(1)
+            Button:
+                text: 'Raise Z-Axis .1mm'
+                on_release: root.moveZ(.1)
+            Button:
+                text: 'Lower Z-Axis 1mm'
+                on_release: root.moveZ(-1)
+            Button:
+                text: 'Lower Z-Axis .1mm'
+                on_release: root.moveZ(-.1)
+            Button:
+                text: 'Define Zero'
+                on_release: root.zeroZ()
+            Label:
+                
 <SetSprocketsVertical>:
     #Set sprockets to 12 o'clock
     GridLayout:
@@ -820,11 +864,11 @@
     vertMeasure:vertMeasure
     unitsBtn:unitsBtn
     enterValues:enterValues
-    zAxisActiveSwitch:zAxisActiveSwitch
     setSprocketsVertical:setSprocketsVertical
     measureOutChains:measureOutChains
     triangularCalibration:triangularCalibration
     finishText:finishText
+    adjustZStep:adjustZStep
 
     cols: 1
     size: root.size
@@ -1015,44 +1059,9 @@
                 id: measureOutChains
         #set z-axis depth
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                size_hint_x: leftCol
-                Label:
-                    text: "Next, we are going to define the home position for the z-axis\n\nIf you have an automatic z-axis installed use the buttons to enable it and adjust the z-axis until the router bit\nbarely touches the surface of the wood. Then press Define Zero\n\nIf you do not have the z-axis installed, adjust your router until the router bit just barely\ntouches the surface of the wood, then press Define Zero"
-                    size_hint_x: leftCol
-                GridLayout:
-                    cols: 2
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Set Z Height.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                GridLayout:
-                    cols: 2
-                    Label:
-                        text: 'Enable\nAutomatic Z-Axis:'
-                    Switch:
-                        on_active: root.enableZaxis()
-                        id: zAxisActiveSwitch
-                Button:
-                    text: 'Raise Z-Axis 1mm'
-                    on_release: root.moveZ(1)
-                Button:
-                    text: 'Raise Z-Axis .1mm'
-                    on_release: root.moveZ(.1)
-                Button:
-                    text: 'Lower Z-Axis 1mm'
-                    on_release: root.moveZ(-1)
-                Button:
-                    text: 'Lower Z-Axis .1mm'
-                    on_release: root.moveZ(-.1)
-                Button:
-                    text: 'Define Zero'
-                    on_release: root.zeroZ()
-                Label:
+            cols: 1
+            AdjustZCalibrationDepth:
+                id: adjustZStep
         #choose kinematics type
         GridLayout:
             cols: 2

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -697,6 +697,8 @@
             Label:
 
 <MeasureDistBetweenMotors>
+    distToMove:distToMove
+    distText:distText
     GridLayout:
         cols: 2
         width: root.width
@@ -719,14 +721,18 @@
             size_hint_x: rightCol
             Label:
             Label:
-                text: "Dist:"
+                text: "Dist(MM):"
+                id: distText
             Button:
-                text: "100mm"
+                text: "100"
                 on_release: root.textInputPopup(self)
+                id: distToMove
             Button:
                 text: "Extend"
+                on_release: root.extend()
             Button:
                 text: "Retract"
+                on_release: root.retract()
             Button:
                 text: 'Pull Chain Tight'
                 on_release: root.pullChainTight()

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -698,6 +698,7 @@
 
 <AdjustZCalibrationDepth>:
     zAxisActiveSwitch:zAxisActiveSwitch
+    openZPopupBtn:openZPopupBtn
     GridLayout:
         cols: 2
         width: root.width
@@ -724,17 +725,10 @@
                     on_active: root.enableZaxis()
                     id: zAxisActiveSwitch
             Button:
-                text: 'Raise Z-Axis 1mm'
-                on_release: root.moveZ(1)
-            Button:
-                text: 'Raise Z-Axis .1mm'
-                on_release: root.moveZ(.1)
-            Button:
-                text: 'Lower Z-Axis 1mm'
-                on_release: root.moveZ(-1)
-            Button:
-                text: 'Lower Z-Axis .1mm'
-                on_release: root.moveZ(-.1)
+                text: "Adjust Z-Axis"
+                on_release: root.zAxisPopup()
+                disabled:True
+                id: openZPopupBtn
             Button:
                 text: 'Define Zero'
                 on_release: root.zeroZ()

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -696,6 +696,48 @@
                 on_release: root.stopCut()
             Label:
 
+<MeasureDistBetweenMotors>
+    GridLayout:
+        cols: 2
+        width: root.width
+        height: root.height
+        GridLayout:
+            cols: 1
+            Label:
+                text: "Rather than using a tape measure to measure the spacing between the motors, we're going to use the chain.\n\nHook the first link from the left chain over the top tooth on the left motor\n\nThen, use the buttons to the right to extend the chain until it can reach the right motor.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way\n\nHook the third link on the right motor's 12:00 tooth as shown in the picture below\n\nPull the chain tight by pressing Pull Chain Tight. You can use this button repeatedly if needed\n\nPress Measure when the chain is taught"
+                size_hint_x: leftCol
+            GridLayout:
+                cols: 3
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Chain On Left Sprocket.jpg"
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Chain Between Sprockets.jpg"
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Chain On Right Sprocket.jpg"
+        GridLayout:
+            cols: 1
+            size_hint_x: rightCol
+            Label:
+            Label:
+                text: "Dist:"
+            Button:
+                text: "100mm"
+                on_release: root.textInputPopup(self)
+            Button:
+                text: "Extend"
+            Button:
+                text: "Retract"
+            Button:
+                text: 'Pull Chain Tight'
+                on_release: root.pullChainTight()
+            Button:
+                text: 'Measure'
+                on_release: root.measureLeft()
+            Button:
+                text: "Stop\nMotors"
+                on_release: root.stopCut()
+            Label:
+
 <AdjustZCalibrationDepth>:
     zAxisActiveSwitch:zAxisActiveSwitch
     openZPopupBtn:openZPopupBtn
@@ -863,6 +905,7 @@
     triangularCalibration:triangularCalibration
     finishText:finishText
     adjustZStep:adjustZStep
+    measureMotorDist:measureMotorDist
 
     cols: 1
     size: root.size
@@ -920,47 +963,11 @@
             cols: 1
             SetSprocketsVertical:
                 id: setSprocketsVertical
+        #Measure the distance between the motors
         GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                Label:
-                    text: "Rather than using a tape measure to measure the spacing between the motors, we're going to use the chain.\n\nHook the first link from the left chain over the top tooth on the left motor\n\nThen, use the buttons to the right to extend the chain until it can reach the right motor.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way\n\nHook the third link on the right motor's 12:00 tooth as shown in the picture below\n\nPull the chain tight by pressing Pull Chain Tight. You can use this button repeatedly if needed\n\nPress Measure when the chain is taught"
-                    size_hint_x: leftCol
-                GridLayout:
-                    cols: 3
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Chain On Left Sprocket.jpg"
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Chain Between Sprockets.jpg"
-                    Image:
-                        source: "./Documentation/Calibrate Machine Dimensions/Chain On Right Sprocket.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                Button:
-                    text: 'Extend Left Chain 1mm'
-                    on_release: root.extendLeft(1)
-                Button:
-                    text: 'Extend Left Chain 10mm'
-                    on_release: root.extendLeft(10)
-                Button:
-                    text: 'Extend Left Chain 100mm'
-                    on_release: root.extendLeft(100)
-                Button:
-                    text: 'Extend Left Chain 1000mm'
-                    on_release: root.extendLeft(1000)
-                Button:
-                    text: 'Pull Chain Tight'
-                    on_release: root.pullChainTight()
-                Button:
-                    text: 'Measure'
-                    on_release: root.measureLeft()
-                Button:
-                    text: "Stop\nMotors"
-                    on_release: root.stopCut()
-                Label:
+            cols: 1
+            MeasureDistBetweenMotors:
+                id: measureMotorDist
         #Measure sled spacing
         GridLayout:
             cols: 2


### PR DESCRIPTION
Instead of requiring you to extend the chain by 1000, 100, or 10mm you can now extend it by an arbitrary length entered using the standard text entry widget:

![image](https://user-images.githubusercontent.com/9359447/35709880-81cdbc4e-0769-11e8-80c9-934f1d8666a4.png)

![image](https://user-images.githubusercontent.com/9359447/35709892-886d4de4-0769-11e8-9f35-b0762d5912ab.png)

Fixes #350 

Should not be merged until after #604 

Needs to be fully tested during a calibration process before merging 