### PR TITLE
A proposed fix for #306

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -38,12 +38,16 @@ class SerialPortThread(MakesmithInitFuncs):
         message = message + '\n'
         
         self.bufferSpace       = self.bufferSpace - len(message)        #shrink the available buffer space by the length of the line
+        
         self.machineIsReadyForData = False
         
         #if this is a quick message sent as soon as the button is pressed (like stop) then put it on the right side of the queue
         #because it is the first message sent, otherwise put it at the end (left) because it is the last message sent
         if isQuickCommand:
-            self.lengthOfLastLineStack.append(len(message))
+            if message[0] == '!':
+                self.lengthOfLastLineStack.append(256) #if we've just sent a stop command, the buffer is now empty on the arduino side
+            else:
+                self.lengthOfLastLineStack.append(len(message))
         else:
             self.lengthOfLastLineStack.appendleft(len(message))
         
@@ -123,6 +127,8 @@ class SerialPortThread(MakesmithInitFuncs):
                     self.machineIsReadyForData = True
                     if bool(self.lengthOfLastLineStack) is True:                                     #if we've sent lines to the machine
                         self.bufferSpace = self.bufferSpace + self.lengthOfLastLineStack.pop()    #free up that space in the buffer
+                        if self.bufferSpace > 256:
+                            self.bufferSpace = 256
                 
                 
                 


### PR DESCRIPTION
This is a proposed fix for the issue where the machine will not move again after pressing the stop button.

The solution is to indicate that when a stop has been sent it will free up the entire buffer. As soon as the OK message is recieved to indicate that the stop command has been processed the entire buffer is marked as free.

One more change I would like to make if we like this solution is to change all of the hard coded 256s in there to be a #define so it is more clear why that number is used and the code can be easily modified for different buffer sizes.

Closes #306 