### PR TITLE
Add Chain Wrap Direction

### DIFF
--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -199,6 +199,8 @@ class MeasureMachinePopup(GridLayout):
         self.carousel.load_next()
 
     def readVerticalOffset(self, dist):
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Bottom':
+            dist *= -1
         print "vertical offset measured at: " + str(dist)
         self.data.config.set('Maslow Settings', 'motorOffsetY', str(dist))
         self.data.config.write()

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -10,11 +10,10 @@ from   UIElements.touchNumberInput               import   TouchNumberInput
 from   UIElements.triangularCalibration          import   TriangularCalibration
 from   kivy.uix.popup                            import   Popup
 import global_variables
-import math
 
 class MeasureMachinePopup(GridLayout):
     done                         = ObjectProperty(None)
-    stepText                     = StringProperty("Step 1 of 11")
+    stepText                     = StringProperty("Step 1 of 10")
     numberOfTimesTestCutRun      = -2
     kinematicsType               = 'Quadrilateral'
 
@@ -49,10 +48,10 @@ class MeasureMachinePopup(GridLayout):
 
         '''
 
-        if self.carousel.index == 11 and self.kinematicsType == 'Quadrilateral':                                        #if we're at the test cut for quadrilateral and we want to go back to choosing kinematics type
+        if self.carousel.index == 10 and self.kinematicsType == 'Quadrilateral':                                        #if we're at the test cut for quadrilateral and we want to go back to choosing kinematics type
+            self.carousel.load_slide(self.carousel.slides[8])
+        elif self.carousel.index == 11 and self.kinematicsType == 'Triangular':                                      #if we're at the last step and need to go back but but we want to go back to the triangular kinematics test cut
             self.carousel.load_slide(self.carousel.slides[9])
-        elif self.carousel.index == 12 and self.kinematicsType == 'Triangular':                                      #if we're at the last step and need to go back but but we want to go back to the triangular kinematics test cut
-            self.carousel.load_slide(self.carousel.slides[10])
         else:
             self.carousel.load_previous()
 
@@ -63,10 +62,10 @@ class MeasureMachinePopup(GridLayout):
 
         '''
 
-        if self.carousel.index == 9 and self.kinematicsType == 'Quadrilateral':                                         #If the kinematics type is quadrilateral skip to the quadrilateral test
+        if self.carousel.index == 8 and self.kinematicsType == 'Quadrilateral':                                         #If the kinematics type is quadrilateral skip to the quadrilateral test
+            self.carousel.load_slide(self.carousel.slides[10])
+        elif self.carousel.index == 9 and self.kinematicsType == 'Triangular':                                       #If we're in the cut test shape triangular and we want to skip to the end
             self.carousel.load_slide(self.carousel.slides[11])
-        elif self.carousel.index == 10 and self.kinematicsType == 'Triangular':                                       #If we're in the cut test shape triangular and we want to skip to the end
-            self.carousel.load_slide(self.carousel.slides[12])
         else:
             self.carousel.load_next()
 
@@ -75,74 +74,70 @@ class MeasureMachinePopup(GridLayout):
         if self.carousel.index == 0:
             #begin notes
             self.goBackBtn.disabled = True
-            self.stepText = "Step 1 of 11"
+            self.stepText = "Step 1 of 10"
 
         if self.carousel.index == 1:
             #pointing one sprocket up
             self.goBackBtn.disabled = False
-            self.stepText = "Step 2 of 11"
+            self.stepText = "Step 2 of 10"
 
         if self.carousel.index == 2:
-            #setting chainOverSprocket
-            self.stepText = "Step 3 of 11"
-
-        if self.carousel.index == 3:
             #measuring distance between motors
             self.data.measureRequest = self.readMotorSpacing
-            self.stepText = "Step 4 of 11"
+            self.stepText = "Step 3 of 10"
 
-        if self.carousel.index == 4:
+        if self.carousel.index == 3:
             #measure sled spacing
-            self.stepText = "Step 5 of 11"
+            self.stepText = "Step 4 of 10"
             pass
 
-        if self.carousel.index == 5:
+        if self.carousel.index == 4:
             #measure vertical distance to wood
             self.data.measureRequest = self.readVerticalOffset
-            self.stepText = "Step 6 of 11"
+            self.stepText = "Step 5 of 10"
 
-        if self.carousel.index == 6:
+        if self.carousel.index == 5:
             #review calculations
             self.updateReviewValuesText()
-            self.stepText = "Step 7 of 11"
+            self.stepText = "Step 6 of 10"
+
+        if self.carousel.index == 6:
+            #Calibrate chain lengths
+            self.stepText = "Step 7 of 10"
 
         if self.carousel.index == 7:
-            #Calibrate chain lengths
-            self.stepText = "Step 8 of 11"
-
-        if self.carousel.index == 8:
             #set up z-axis
             if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
                 self.zAxisActiveSwitch.active = True
             else:
                 self.zAxisActiveSwitch.active = False
-            self.stepText = "Step 9 of 11"
+            self.stepText = "Step 8 of 10"
+
+        if self.carousel.index == 8:
+            #Choose kinematics type
+            self.stepText = "Step 9 of 10"
 
         if self.carousel.index == 9:
-            #Choose kinematics type
-            self.stepText = "Step 10 of 11"
-
-        if self.carousel.index == 10:
             #Cut test shape triangular
             self.data.pushSettings()
-            self.stepText = "Step 11 of 11"
+            self.stepText = "Step 10 of 10"
             self.goFwdBtn.disabled = False
 
             #if we're not supposed to be in triangular calibration go to the next page
             if self.kinematicsType != 'Triangular':
                 self.carousel.load_next()
 
-        if self.carousel.index == 11:
+        if self.carousel.index == 10:
             #Cut test shape quadrilateral
             self.data.pushSettings()
             self.goFwdBtn.disabled = False
-            self.stepText = "Step 11 of 11"
+            self.stepText = "Step 10 of 10"
 
             #if we're not supposed to be in quadratic calibration go to finished
             if self.kinematicsType == 'Triangular':
                 self.carousel.load_next()
 
-        if self.carousel.index == 12:
+        if self.carousel.index == 11:
             #Final finish step
             self.goFwdBtn.disabled = True
             finishString = "Your machine is now calibrated!\n\nCongratulations!\n\nThe final calibration values are:\n"
@@ -172,25 +167,28 @@ class MeasureMachinePopup(GridLayout):
             
     def extendLeft(self, dist):
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L" + str(dist) + " ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L" + str(dist) + " ")
+        else:
+            self.data.gcode_queue.put("B09 L-" + str(dist) + " ")
         self.data.gcode_queue.put("G90 ")
 
     def retractLeft(self, dist):
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L-" + str(dist) + " ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L-" + str(dist) + " ")
+        else:
+            self.data.gcode_queue.put("B09 L" + str(dist) + " ")
         self.data.gcode_queue.put("G90 ")
 
     def measureLeft(self):
         self.data.gcode_queue.put("B10 L")
 
     def readMotorSpacing(self, dist):
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Bottom':
+            dist *= -1
 
         dist = dist - 2*6.35                                #subtract off the extra two links
-
-        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Bottom':
-            motorSprocketRadius = (float(self.data.config.get('Advanced Settings', 'gearTeeth')) * float(self.data.config.get('Advanced Settings', 'chainPitch'))) / (2 * 3.14159)
-            dist -= motorSprocketRadius * 3.14159
-            dist = math.sqrt(math.pow(dist,2) - math.pow((2*motorSprocketRadius),2))
 
         print "Read motor spacing: " + str(dist)
         self.data.config.set('Maslow Settings', 'motorSpacingX', str(dist))
@@ -342,7 +340,7 @@ class MeasureMachinePopup(GridLayout):
             self.carousel.load_next()
         else:
 
-            self.carousel.load_slide(self.carousel.slides[11])
+            self.carousel.load_slide(self.carousel.slides[10])
 
     def cutTestPatern(self):
 
@@ -438,28 +436,4 @@ class MeasureMachinePopup(GridLayout):
 
         '''
         self.data.gcode_queue.put("G10 Z0 ")
-        self.carousel.load_next()
-
-    def chainsOnTop(self):
-        '''
-
-        Set chainOverSprocket to Top
-
-        '''
-        print "Setting chainOverSprocket to: Top"
-        self.data.config.set('Advanced Settings', 'chainOverSprocket', 'Top')
-        self.data.config.write()
-        self.data.pushSettings()
-        self.carousel.load_next()
-
-    def chainsOnBottom(self):
-        '''
-
-        Set chainOverSprocket to Bottom
-
-        '''
-        print "Setting chainOverSprocket to: Bottom"
-        self.data.config.set('Advanced Settings', 'chainOverSprocket', 'Bottom')
-        self.data.config.write()
-        self.data.pushSettings()
         self.carousel.load_next()

--- a/UIElements/measureMachinePopup.py
+++ b/UIElements/measureMachinePopup.py
@@ -10,10 +10,11 @@ from   UIElements.touchNumberInput               import   TouchNumberInput
 from   UIElements.triangularCalibration          import   TriangularCalibration
 from   kivy.uix.popup                            import   Popup
 import global_variables
+import math
 
 class MeasureMachinePopup(GridLayout):
     done                         = ObjectProperty(None)
-    stepText                     = StringProperty("Step 1 of 10")
+    stepText                     = StringProperty("Step 1 of 11")
     numberOfTimesTestCutRun      = -2
     kinematicsType               = 'Quadrilateral'
 
@@ -48,10 +49,10 @@ class MeasureMachinePopup(GridLayout):
 
         '''
 
-        if self.carousel.index == 10 and self.kinematicsType == 'Quadrilateral':                                        #if we're at the test cut for quadrilateral and we want to go back to choosing kinematics type
-            self.carousel.load_slide(self.carousel.slides[8])
-        elif self.carousel.index == 11 and self.kinematicsType == 'Triangular':                                      #if we're at the last step and need to go back but but we want to go back to the triangular kinematics test cut
+        if self.carousel.index == 11 and self.kinematicsType == 'Quadrilateral':                                        #if we're at the test cut for quadrilateral and we want to go back to choosing kinematics type
             self.carousel.load_slide(self.carousel.slides[9])
+        elif self.carousel.index == 12 and self.kinematicsType == 'Triangular':                                      #if we're at the last step and need to go back but but we want to go back to the triangular kinematics test cut
+            self.carousel.load_slide(self.carousel.slides[10])
         else:
             self.carousel.load_previous()
 
@@ -62,10 +63,10 @@ class MeasureMachinePopup(GridLayout):
 
         '''
 
-        if self.carousel.index == 8 and self.kinematicsType == 'Quadrilateral':                                         #If the kinematics type is quadrilateral skip to the quadrilateral test
-            self.carousel.load_slide(self.carousel.slides[10])
-        elif self.carousel.index == 9 and self.kinematicsType == 'Triangular':                                       #If we're in the cut test shape triangular and we want to skip to the end
+        if self.carousel.index == 9 and self.kinematicsType == 'Quadrilateral':                                         #If the kinematics type is quadrilateral skip to the quadrilateral test
             self.carousel.load_slide(self.carousel.slides[11])
+        elif self.carousel.index == 10 and self.kinematicsType == 'Triangular':                                       #If we're in the cut test shape triangular and we want to skip to the end
+            self.carousel.load_slide(self.carousel.slides[12])
         else:
             self.carousel.load_next()
 
@@ -74,70 +75,74 @@ class MeasureMachinePopup(GridLayout):
         if self.carousel.index == 0:
             #begin notes
             self.goBackBtn.disabled = True
-            self.stepText = "Step 1 of 10"
+            self.stepText = "Step 1 of 11"
 
         if self.carousel.index == 1:
             #pointing one sprocket up
             self.goBackBtn.disabled = False
-            self.stepText = "Step 2 of 10"
+            self.stepText = "Step 2 of 11"
 
         if self.carousel.index == 2:
-            #measuring distance between motors
-            self.data.measureRequest = self.readMotorSpacing
-            self.stepText = "Step 3 of 10"
+            #setting chainOverSprocket
+            self.stepText = "Step 3 of 11"
 
         if self.carousel.index == 3:
-            #measure sled spacing
-            self.stepText = "Step 4 of 10"
-            pass
+            #measuring distance between motors
+            self.data.measureRequest = self.readMotorSpacing
+            self.stepText = "Step 4 of 11"
 
         if self.carousel.index == 4:
-            #measure vertical distance to wood
-            self.data.measureRequest = self.readVerticalOffset
-            self.stepText = "Step 5 of 10"
+            #measure sled spacing
+            self.stepText = "Step 5 of 11"
+            pass
 
         if self.carousel.index == 5:
-            #review calculations
-            self.updateReviewValuesText()
-            self.stepText = "Step 6 of 10"
+            #measure vertical distance to wood
+            self.data.measureRequest = self.readVerticalOffset
+            self.stepText = "Step 6 of 11"
 
         if self.carousel.index == 6:
-            #Calibrate chain lengths
-            self.stepText = "Step 7 of 10"
+            #review calculations
+            self.updateReviewValuesText()
+            self.stepText = "Step 7 of 11"
 
         if self.carousel.index == 7:
+            #Calibrate chain lengths
+            self.stepText = "Step 8 of 11"
+
+        if self.carousel.index == 8:
             #set up z-axis
             if int(self.data.config.get('Maslow Settings', 'zAxis')) == 1:
                 self.zAxisActiveSwitch.active = True
             else:
                 self.zAxisActiveSwitch.active = False
-            self.stepText = "Step 8 of 10"
-
-        if self.carousel.index == 8:
-            #Choose kinematics type
-            self.stepText = "Step 9 of 10"
+            self.stepText = "Step 9 of 11"
 
         if self.carousel.index == 9:
+            #Choose kinematics type
+            self.stepText = "Step 10 of 11"
+
+        if self.carousel.index == 10:
             #Cut test shape triangular
             self.data.pushSettings()
-            self.stepText = "Step 10 of 10"
+            self.stepText = "Step 11 of 11"
             self.goFwdBtn.disabled = False
 
             #if we're not supposed to be in triangular calibration go to the next page
             if self.kinematicsType != 'Triangular':
                 self.carousel.load_next()
 
-        if self.carousel.index == 10:
+        if self.carousel.index == 11:
             #Cut test shape quadrilateral
             self.data.pushSettings()
             self.goFwdBtn.disabled = False
-            self.stepText = "Step 10 of 10"
+            self.stepText = "Step 11 of 11"
 
             #if we're not supposed to be in quadratic calibration go to finished
             if self.kinematicsType == 'Triangular':
                 self.carousel.load_next()
 
-        if self.carousel.index == 11:
+        if self.carousel.index == 12:
             #Final finish step
             self.goFwdBtn.disabled = True
             finishString = "Your machine is now calibrated!\n\nCongratulations!\n\nThe final calibration values are:\n"
@@ -181,6 +186,11 @@ class MeasureMachinePopup(GridLayout):
     def readMotorSpacing(self, dist):
 
         dist = dist - 2*6.35                                #subtract off the extra two links
+
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Bottom':
+            motorSprocketRadius = (float(self.data.config.get('Advanced Settings', 'gearTeeth')) * float(self.data.config.get('Advanced Settings', 'chainPitch'))) / (2 * 3.14159)
+            dist -= motorSprocketRadius * 3.14159
+            dist = math.sqrt(math.pow(dist,2) - math.pow((2*motorSprocketRadius),2))
 
         print "Read motor spacing: " + str(dist)
         self.data.config.set('Maslow Settings', 'motorSpacingX', str(dist))
@@ -332,7 +342,7 @@ class MeasureMachinePopup(GridLayout):
             self.carousel.load_next()
         else:
 
-            self.carousel.load_slide(self.carousel.slides[10])
+            self.carousel.load_slide(self.carousel.slides[11])
 
     def cutTestPatern(self):
 
@@ -428,4 +438,28 @@ class MeasureMachinePopup(GridLayout):
 
         '''
         self.data.gcode_queue.put("G10 Z0 ")
+        self.carousel.load_next()
+
+    def chainsOnTop(self):
+        '''
+
+        Set chainOverSprocket to Top
+
+        '''
+        print "Setting chainOverSprocket to: Top"
+        self.data.config.set('Advanced Settings', 'chainOverSprocket', 'Top')
+        self.data.config.write()
+        self.data.pushSettings()
+        self.carousel.load_next()
+
+    def chainsOnBottom(self):
+        '''
+
+        Set chainOverSprocket to Bottom
+
+        '''
+        print "Setting chainOverSprocket to: Bottom"
+        self.data.config.set('Advanced Settings', 'chainOverSprocket', 'Bottom')
+        self.data.config.write()
+        self.data.pushSettings()
         self.carousel.load_next()

--- a/UIElements/setSprocketsVertical.py
+++ b/UIElements/setSprocketsVertical.py
@@ -12,73 +12,109 @@ class SetSprocketsVertical(Widget):
     def LeftCW(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/360.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def LeftCCW(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/360.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def RightCW(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/360.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def RightCCW(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/360.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def LeftCW5(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/72.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def LeftCCW5(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/72.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def RightCW5(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/72.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def RightCCW5(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/72.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def LeftCWpoint1(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/3600.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def LeftCCWpoint1(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/3600.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def RightCWpoint1(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/3600.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def RightCCWpoint1(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/3600.0;
         self.data.gcode_queue.put("G91 ")
-        self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
         self.data.gcode_queue.put("G90 ")
 
     def setZero(self):

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -357,7 +357,7 @@ class TriangularCalibration(Widget):
         self.data.gcode_queue.put("G40 ")
         self.data.gcode_queue.put("G0 X0 Y0 ")
 
-        self.carousel.load_slide(self.carousel.slides[12])
+        self.carousel.load_slide(self.carousel.slides[11])
 
     def stopCut(self):
         self.data.quick_queue.put("!") 

--- a/UIElements/triangularCalibration.py
+++ b/UIElements/triangularCalibration.py
@@ -143,6 +143,10 @@ class TriangularCalibration(Widget):
         motorYcoordEst = (workspaceHeight/2) + motorYoffsetEst
         rotationRadiusEst = float(self.data.config.get('Advanced Settings', 'rotationRadius'))
         chainSagCorrectionEst = float(self.data.config.get('Advanced Settings', 'chainSagCorrection'))
+        if str(self.data.config.get('Advanced Settings', 'chainOverSprocket')) == 'Top':
+            chainOverSprocket = 1
+        else:
+            chainOverSprocket = 2
         gearTeeth = float(self.data.config.get('Advanced Settings', 'gearTeeth'))
         chainPitch = float(self.data.config.get('Advanced Settings', 'chainPitch'))
         motorSprocketRadius = (gearTeeth*chainPitch)/(2*3.14159)
@@ -154,11 +158,27 @@ class TriangularCalibration(Widget):
         MotorDistanceCut3 = math.sqrt(math.pow(motorXcoord - ((workspaceWidth/2)-254),2) + math.pow(motorYcoordEst + ((workspaceHeight/2)-254),2))
         MotorDistanceCut4 = math.sqrt(math.pow(motorXcoord + ((workspaceWidth/2)-254),2) + math.pow(motorYcoordEst + ((workspaceHeight/2)-254),2))
 
-        #Calculate the chain angles from horizontal
-        ChainAngleCut1 = 3.14159 - math.acos(motorSprocketRadius/MotorDistanceCut1) - math.acos((motorYcoordEst - ((workspaceHeight/2)-254)) / MotorDistanceCut1)
-        ChainAngleCut2 = 3.14159 - math.acos(motorSprocketRadius/MotorDistanceCut2) - math.acos((motorYcoordEst - ((workspaceHeight/2)-254)) / MotorDistanceCut2)
-        ChainAngleCut3 = 3.14159 - math.acos(motorSprocketRadius/MotorDistanceCut3) - math.acos((motorYcoordEst + ((workspaceHeight/2)-254)) / MotorDistanceCut3)
-        ChainAngleCut4 = 3.14159 - math.acos(motorSprocketRadius/MotorDistanceCut4) - math.acos((motorYcoordEst + ((workspaceHeight/2)-254)) / MotorDistanceCut4)
+        #Calculate the chain angles from horizontal, based on if the chain connects to the sled from the top or bottom of the sprocket
+        if chainOverSprocket == 1:
+            ChainAngleCut1 = math.asin((motorYcoordEst - ((workspaceHeight/2)-254)) / MotorDistanceCut1) + math.asin(motorSprocketRadius/MotorDistanceCut1)
+            ChainAngleCut2 = math.asin((motorYcoordEst - ((workspaceHeight/2)-254)) / MotorDistanceCut2) + math.asin(motorSprocketRadius/MotorDistanceCut2)
+            ChainAngleCut3 = math.asin((motorYcoordEst + ((workspaceHeight/2)-254)) / MotorDistanceCut3) + math.asin(motorSprocketRadius/MotorDistanceCut3)
+            ChainAngleCut4 = math.asin((motorYcoordEst + ((workspaceHeight/2)-254)) / MotorDistanceCut4) + math.asin(motorSprocketRadius/MotorDistanceCut4)
+
+            ChainAroundSprocketCut1 = motorSprocketRadius * ChainAngleCut1
+            ChainAroundSprocketCut2 = motorSprocketRadius * ChainAngleCut2
+            ChainAroundSprocketCut3 = motorSprocketRadius * ChainAngleCut3
+            ChainAroundSprocketCut4 = motorSprocketRadius * ChainAngleCut4
+        else:
+            ChainAngleCut1 = math.asin((motorYcoordEst - ((workspaceHeight/2)-254)) / MotorDistanceCut1) - math.asin(motorSprocketRadius/MotorDistanceCut1)
+            ChainAngleCut2 = math.asin((motorYcoordEst - ((workspaceHeight/2)-254)) / MotorDistanceCut2) - math.asin(motorSprocketRadius/MotorDistanceCut2)
+            ChainAngleCut3 = math.asin((motorYcoordEst + ((workspaceHeight/2)-254)) / MotorDistanceCut3) - math.asin(motorSprocketRadius/MotorDistanceCut3)
+            ChainAngleCut4 = math.asin((motorYcoordEst + ((workspaceHeight/2)-254)) / MotorDistanceCut4) - math.asin(motorSprocketRadius/MotorDistanceCut4)
+
+            ChainAroundSprocketCut1 = motorSprocketRadius * (3.14159 - ChainAngleCut1)
+            ChainAroundSprocketCut2 = motorSprocketRadius * (3.14159 - ChainAngleCut2)
+            ChainAroundSprocketCut3 = motorSprocketRadius * (3.14159 - ChainAngleCut3)
+            ChainAroundSprocketCut4 = motorSprocketRadius * (3.14159 - ChainAngleCut4)
 
         #Calculate the straight chain length from the sprocket to the bit
         ChainStraightCut1 = math.sqrt(math.pow(MotorDistanceCut1,2) - math.pow(motorSprocketRadius,2))
@@ -173,10 +193,10 @@ class TriangularCalibration(Widget):
         ChainStraightCut4 *= (1 + ((chainSagCorrectionEst / 1000000000000) * math.pow(math.cos(ChainAngleCut4),2) * math.pow(ChainStraightCut4,2) * math.pow((math.tan(ChainAngleCut3) * math.cos(ChainAngleCut4)) + math.sin(ChainAngleCut4),2)))
 
         #Calculate total chain lengths accounting for sprocket geometry and chain sag
-        ChainLengthCut1 = (motorSprocketRadius * ChainAngleCut1) + ChainStraightCut1;
-        ChainLengthCut2 = (motorSprocketRadius * ChainAngleCut2) + ChainStraightCut2;
-        ChainLengthCut3 = (motorSprocketRadius * ChainAngleCut3) + ChainStraightCut3;
-        ChainLengthCut4 = (motorSprocketRadius * ChainAngleCut4) + ChainStraightCut4;
+        ChainLengthCut1 = ChainAroundSprocketCut1 + ChainStraightCut1
+        ChainLengthCut2 = ChainAroundSprocketCut2 + ChainStraightCut2
+        ChainLengthCut3 = ChainAroundSprocketCut3 + ChainStraightCut3
+        ChainLengthCut4 = ChainAroundSprocketCut4 + ChainStraightCut4
 
         #Subtract of the virtual length which is added to the chain by the rotation mechanism
         ChainLengthCut1 -= rotationRadiusEst
@@ -213,11 +233,27 @@ class TriangularCalibration(Widget):
             MotorDistanceCut3Est = math.sqrt(math.pow(motorXcoord - (distBetweenCuts34 / 2),2) + math.pow(motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst,2))
             MotorDistanceCut4Est = math.sqrt(math.pow(motorXcoord + (distBetweenCuts34 / 2),2) + math.pow(motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst,2))
 
-            #Calculate the chain angles from horizontal
-            ChainAngleCut1Est = 3.14159 - math.acos(motorSprocketRadius / MotorDistanceCut1Est) - math.acos(motorYcoordEst / MotorDistanceCut1Est)
-            ChainAngleCut2Est = 3.14159 - math.acos(motorSprocketRadius / MotorDistanceCut2Est) - math.acos(motorYcoordEst / MotorDistanceCut2Est)
-            ChainAngleCut3Est = 3.14159 - math.acos(motorSprocketRadius / MotorDistanceCut3Est) - math.acos((motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst) / MotorDistanceCut3Est)
-            ChainAngleCut4Est = 3.14159 - math.acos(motorSprocketRadius / MotorDistanceCut4Est) - math.acos((motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst) / MotorDistanceCut4Est)
+            #Calculate the chain angles from horizontal, based on if the chain connects to the sled from the top or bottom of the sprocket
+            if chainOverSprocket == 1:
+                ChainAngleCut1Est = math.asin(motorYcoordEst / MotorDistanceCut1Est) + math.asin(motorSprocketRadius / MotorDistanceCut1Est)
+                ChainAngleCut2Est = math.asin(motorYcoordEst / MotorDistanceCut2Est) + math.asin(motorSprocketRadius / MotorDistanceCut2Est)
+                ChainAngleCut3Est = math.asin((motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst) / MotorDistanceCut3Est) + math.asin(motorSprocketRadius / MotorDistanceCut3Est)
+                ChainAngleCut4Est = math.asin((motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst) / MotorDistanceCut4Est) + math.asin(motorSprocketRadius / MotorDistanceCut4Est)
+
+                ChainAroundSprocketCut1Est = motorSprocketRadius * ChainAngleCut1Est
+                ChainAroundSprocketCut2Est = motorSprocketRadius * ChainAngleCut2Est
+                ChainAroundSprocketCut3Est = motorSprocketRadius * ChainAngleCut3Est
+                ChainAroundSprocketCut4Est = motorSprocketRadius * ChainAngleCut4Est
+            else:
+                ChainAngleCut1Est = math.asin(motorYcoordEst / MotorDistanceCut1Est) - math.asin(motorSprocketRadius / MotorDistanceCut1Est)
+                ChainAngleCut2Est = math.asin(motorYcoordEst / MotorDistanceCut2Est) - math.asin(motorSprocketRadius / MotorDistanceCut2Est)
+                ChainAngleCut3Est = math.asin((motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst) / MotorDistanceCut3Est) - math.asin(motorSprocketRadius / MotorDistanceCut3Est)
+                ChainAngleCut4Est = math.asin((motorYcoordEst + (workspaceHeight-508) - cut34YoffsetEst) / MotorDistanceCut4Est) - math.asin(motorSprocketRadius / MotorDistanceCut4Est)
+
+                ChainAroundSprocketCut1Est = motorSprocketRadius * (3.14159 - ChainAngleCut1Est)
+                ChainAroundSprocketCut2Est = motorSprocketRadius * (3.14159 - ChainAngleCut2Est)
+                ChainAroundSprocketCut3Est = motorSprocketRadius * (3.14159 - ChainAngleCut3Est)
+                ChainAroundSprocketCut4Est = motorSprocketRadius * (3.14159 - ChainAngleCut4Est)
 
             #Calculate the straight chain length from the sprocket to the bit
             ChainStraightCut1Est = math.sqrt(math.pow(MotorDistanceCut1Est,2) - math.pow(motorSprocketRadius,2))
@@ -232,10 +268,10 @@ class TriangularCalibration(Widget):
             ChainStraightCut4Est *= (1 + ((chainSagCorrectionEst / 1000000000000) * math.pow(math.cos(ChainAngleCut4Est),2) * math.pow(ChainStraightCut4Est,2) * math.pow((math.tan(ChainAngleCut3Est) * math.cos(ChainAngleCut4Est)) + math.sin(ChainAngleCut4Est),2)))
 
             #Calculate total chain lengths accounting for sprocket geometry and chain sag
-            ChainLengthCut1Est = (motorSprocketRadius * ChainAngleCut1Est) + ChainStraightCut1Est;
-            ChainLengthCut2Est = (motorSprocketRadius * ChainAngleCut2Est) + ChainStraightCut2Est;
-            ChainLengthCut3Est = (motorSprocketRadius * ChainAngleCut3Est) + ChainStraightCut3Est;
-            ChainLengthCut4Est = (motorSprocketRadius * ChainAngleCut4Est) + ChainStraightCut4Est;
+            ChainLengthCut1Est = ChainAroundSprocketCut1Est + ChainStraightCut1Est
+            ChainLengthCut2Est = ChainAroundSprocketCut2Est + ChainStraightCut2Est
+            ChainLengthCut3Est = ChainAroundSprocketCut3Est + ChainStraightCut3Est
+            ChainLengthCut4Est = ChainAroundSprocketCut4Est + ChainStraightCut4Est
 
             #Subtract of the virtual length which is added to the chain by the rotation mechanism
             ChainLengthCut1Est -= rotationRadiusEst
@@ -321,7 +357,7 @@ class TriangularCalibration(Widget):
         self.data.gcode_queue.put("G40 ")
         self.data.gcode_queue.put("G0 X0 Y0 ")
 
-        self.carousel.load_slide(self.carousel.slides[11])
+        self.carousel.load_slide(self.carousel.slides[12])
 
     def stopCut(self):
         self.data.quick_queue.put("!") 

--- a/global_variables.py
+++ b/global_variables.py
@@ -22,6 +22,7 @@ _macro2_title		= "Macro 2"
 _encoderSteps		= 8113.73
 _gearTeeth			= 10
 _chainPitch			= 6.35
+_chainOverSprocket	= 'Top'
 _zEncoderSteps		= 7560.0
 _zAxisAuto			= 0
 _homeX				= 0.0

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -882,6 +882,27 @@
             cols: 1
             SetSprocketsVertical:
                 id: setSprocketsVertical
+        #Set chain above/below sprocket to sled
+        GridLayout:
+            cols: 2
+            GridLayout:
+                cols: 1
+                Label:
+                    text: "In this step we will select on which side of the\nmotor sprockets the chains connect to the sled\n\nSelect the button on the right corresponding to your configuration\n\nBelow is an example of a 'Top' configuration"
+                    size_hint_x: leftCol
+                Image:
+                    source: "./Documentation/Calibrate Machine Dimensions/Chain On Left Sprocket.jpg"
+            GridLayout:
+                cols: 1
+                size_hint_x: rightCol
+                Label:
+                Button:
+                    text: 'Top'
+                    on_release: root.chainsOnTop()
+                Button:
+                    text: 'Bottom'
+                    on_release: root.chainsOnBottom()
+                Label:
         GridLayout:
             cols: 2
             GridLayout:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -882,27 +882,6 @@
             cols: 1
             SetSprocketsVertical:
                 id: setSprocketsVertical
-        #Set chain above/below sprocket to sled
-        GridLayout:
-            cols: 2
-            GridLayout:
-                cols: 1
-                Label:
-                    text: "In this step we will select on which side of the\nmotor sprockets the chains connect to the sled\n\nSelect the button on the right corresponding to your configuration\n\nBelow is an example of a 'Top' configuration"
-                    size_hint_x: leftCol
-                Image:
-                    source: "./Documentation/Calibrate Machine Dimensions/Chain On Left Sprocket.jpg"
-            GridLayout:
-                cols: 1
-                size_hint_x: rightCol
-                Label:
-                Button:
-                    text: 'Top'
-                    on_release: root.chainsOnTop()
-                Button:
-                    text: 'Bottom'
-                    on_release: root.chainsOnBottom()
-                Label:
         GridLayout:
             cols: 2
             GridLayout:

--- a/main.py
+++ b/main.py
@@ -207,6 +207,14 @@ class GroundControlApp(App):
             "key": "chainPitch"
         },
         {
+            "type": "options",
+            "title": "Side of Motor Sprockets That Chains Go to Sled",
+            "desc": "On which side of the motor sprockets the chains connect to the sled\\ndefault setting: %s",
+            "options": ["Top", "Bottom"],
+            "section": "Advanced Settings",
+            "key": "chainOverSprocket"
+        },
+        {
             "type": "string",
             "title": "Z-Axis Encoder Steps per Revolution",
             "desc": "The number of encoder steps per revolution of the z-axis\\ndefault setting: %s",
@@ -338,6 +346,7 @@ class GroundControlApp(App):
         global_variables._encoderSteps,
         global_variables._gearTeeth,
         global_variables._chainPitch,
+        global_variables._chainOverSprocket,
         global_variables._zEncoderSteps,
         global_variables._zAxisAuto,
         global_variables._homeX,
@@ -488,6 +497,7 @@ class GroundControlApp(App):
         config.setdefaults('Advanced Settings', {'encoderSteps'       : global_variables._encoderSteps,
                                                  'gearTeeth'          : global_variables._gearTeeth,
                                                  'chainPitch'         : global_variables._chainPitch,
+                                                 'chainOverSprocket'  : global_variables._chainOverSprocket,
                                                  'zEncoderSteps'      : global_variables._zEncoderSteps,
                                                  'zAxisAuto'          : global_variables._zAxisAuto,
                                                  'homeX'              : global_variables._homeX,
@@ -619,6 +629,12 @@ class GroundControlApp(App):
         self.data.gcode_queue.put("$7=" + str(kinematicsType))
         self.data.gcode_queue.put("$8=" + str(self.data.config.get('Advanced Settings', 'rotationRadius')))
         self.data.gcode_queue.put("$37=" + str(self.data.config.get('Advanced Settings', 'chainSagCorrection')))
+
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            chainOverSprocket = 1
+        else:
+            chainOverSprocket = 2
+        self.data.gcode_queue.put("$38=" + str(chainOverSprocket))
 
 
         


### PR DESCRIPTION
This adds a configuration setting to select which way the chain wraps around the sprocket to go to the motor. Changes are also made to update the simulator and triangular kinematics calibration code, as well as add a calibration step to select the appropriate configuration.

Since I don't have my Maslow yet I was not able to take pictures showing the top versus bottom configurations in the calibration process, so I did my best to utilize already-available images. Additional images may help new users here though.

Note that this does not update the quadrilateral kinematics, so using quadrilateral kinematics with the chains on bottom of the motor sprockets could lead to accuracy errors.

This is the GroundControl PR associated with Firmware [PR 382](https://github.com/MaslowCNC/Firmware/pull/382).