### PR TITLE
Some modifications to the Z-Menu

### DIFF
--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -80,6 +80,8 @@ class Data(EventDispatcher):
     zPush = None
     zPushUnits = 'MM'
     zReadoutPos = 0.00
+    zPopupUnits = None
+    zStepSizeVal = 0.1
     
     '''
     Queues

--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -73,7 +73,13 @@ class Data(EventDispatcher):
     iconPath                                              =  StringProperty('./Images/Icons/normal/')
     posIndicatorColor                                     =  ObjectProperty([0,0,0])
     targetInicatorColor                                   =  ObjectProperty([1,0,0])
-    
+
+    '''
+    Misc UI bits that need to be saved between invocations (but not saved)
+    '''
+    zPush = None
+    zPushUnits = 'MM'
+    zReadoutPos = 0.00
     
     '''
     Queues

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -44,7 +44,6 @@ class FrontPage(Screen, MakesmithInitFuncs):
     tick=0
     
     stepsizeval  = 0
-    zStepSizeVal = .1
     
     consoleText  = StringProperty(" ")
     
@@ -314,7 +313,7 @@ class FrontPage(Screen, MakesmithInitFuncs):
     def zAxisPopup(self):
         self.popupContent      = ZAxisPopupContent(done=self.dismissZAxisPopup)
         self.popupContent.data = self.data
-        self.popupContent.initialize(self.zStepSizeVal)
+        self.popupContent.initialize()
         self._popup = Popup(title="Z-Axis", content=self.popupContent,
                             size_hint=(0.5, 0.5))
         self._popup.open()
@@ -325,10 +324,6 @@ class FrontPage(Screen, MakesmithInitFuncs):
         Close The Z-Axis Pop-up
         
         '''
-        try:
-            self.zStepSizeVal = float(self.popupContent.distBtn.text)
-        except:
-            pass
         self._popup.dismiss()
     
     def home(self):

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -117,6 +117,9 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.yReadoutPos    = self.buildReadoutString(yPos)
         self.zReadoutPos    = self.buildReadoutString(zPos)
         
+        #So other widgets can access the position
+        self.data.zReadoutPos = zPos
+        
         #Current Velocity is done here now, not in the firmware.
         self.tick+=1
         if self.tick>=4:    #Can't do this every time... it's too noisy, so we do it every 5rd time (0.1s).

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -146,4 +146,8 @@ class ZAxisPopupContent(GridLayout):
             self.distBtn.text = str(tempfloat)  # Update displayed text using standard numeric format
         except:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
+        self._popup.dismiss()
+        
+    def close(self):
+        self.data.units=self.onEntryUnits #Restore original units
         self.done()

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -22,14 +22,13 @@ class ZAxisPopupContent(GridLayout):
         Initialize the z-axis popup
         
         '''
+        self.onEntryUnits= self.data.units
         if self.data.zPopupUnits is None:
             self.data.zPopupUnits = self.data.units
         self.unitsBtn.text = self.data.zPopupUnits
         if self.data.zPush is not None:
             self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
             self.zPopDisable = self.data.zPushUnits <> self.data.zPopupUnits
-        self.setMachineUnits()
-        self.onEntryUnits= self.data.units
 
     def setMachineUnits(self):
         self.data.units = self.data.zPopupUnits #Show the right units on the main screen

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -110,6 +110,16 @@ class ZAxisPopupContent(GridLayout):
         
         '''
         self.data.gcode_queue.put("G10 Z0 ")
+        
+    def touchZero(self):
+        '''
+        Probe for Zero Z
+        '''
+        if self.data.units == "INCHES":
+            self.data.gcode_queue.put("G38.2 Z2 F2")
+        else:
+            self.data.gcode_queue.put("G38.2 Z50 F50")
+            
     
     def stopZMove(self):
         '''

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -116,9 +116,9 @@ class ZAxisPopupContent(GridLayout):
         Probe for Zero Z
         '''
         if self.data.units == "INCHES":
-            self.data.gcode_queue.put("G38.2 Z2 F2")
+            self.data.gcode_queue.put("G38.2 Z2 F2")    #Only go down 2 inches...
         else:
-            self.data.gcode_queue.put("G38.2 Z50 F50")
+            self.data.gcode_queue.put("G38.2 Z50 F50")  #Or 50mm.
             
     
     def stopZMove(self):

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -27,12 +27,15 @@ class ZAxisPopupContent(GridLayout):
             self.data.zPopupUnits = self.data.units
         self.unitsBtn.text = self.data.zPopupUnits
         if self.data.zPush is not None:
-            self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
-            self.zPopDisable = self.data.zPushUnits <> self.data.zPopupUnits
-
-    def setMachineUnits(self):
-        self.data.units = self.data.zPopupUnits #Show the right units on the main screen
-        if self.data.zPopupUnits == "INCHES":
+            self.zCutLabel = "Re-Plunge to\n"+'%.2f '%(self.data.zPush)+self.data.zPushUnits[:2]
+            self.zPopDisable=False
+            
+    def setMachineUnits(self, units=None):
+        if units is None:
+            units = self.data.zPopupUnits
+            
+        self.data.units = units #Show the right units on the main screen
+        if units == "INCHES":
             self.data.gcode_queue.put('G20 ')
         else:
             self.data.gcode_queue.put('G21 ')
@@ -64,9 +67,6 @@ class ZAxisPopupContent(GridLayout):
         
         self.distBtn.text = "%.2f"%self.data.zStepSizeVal
         self.unitsBtn.text = self.data.zPopupUnits
-        
-        if self.data.zPush is not None:
-            self.zPopDisable = self.data.zPushUnits <> self.data.units
     
     def goThere(self):
         '''
@@ -100,7 +100,7 @@ class ZAxisPopupContent(GridLayout):
         #Save the current "cut" point
         self.data.zPush = self.data.zReadoutPos
         self.data.zPushUnits = self.data.units
-        self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
+        self.zCutLabel = "Re-Plunge to\n"+'%.2f '%(self.data.zPush)+self.data.zPushUnits[:2]
         self.zPopDisable = False
         
         self.setMachineUnits()
@@ -120,7 +120,7 @@ class ZAxisPopupContent(GridLayout):
         '''
         Move z-axis to last cut (saved point when "move to safety" was pressed
         '''
-        self.setMachineUnits()
+        self.setMachineUnits(self.data.zPushUnits)
         self.data.gcode_queue.put("G00 Z"+str(self.data.zPush))
         self.resetMachineUnits()
     

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -14,6 +14,7 @@ class ZAxisPopupContent(GridLayout):
     zCutLabel = StringProperty("Re-Plunge To\nSaved Depth")
     zPopDisable = ObjectProperty(True)
     unitsArmed=False
+    onEntryUnits=""
     
     def initialize(self):
         '''
@@ -28,14 +29,17 @@ class ZAxisPopupContent(GridLayout):
             self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
             self.zPopDisable = self.data.zPushUnits <> self.data.zPopupUnits
         self.setMachineUnits()
+        self.onEntryUnits= self.data.units
 
     def setMachineUnits(self):
+        self.data.units = self.data.zPopupUnits #Show the right units on the main screen
         if self.data.zPopupUnits == "INCHES":
             self.data.gcode_queue.put('G20 ')
         else:
             self.data.gcode_queue.put('G21 ')
 
     def resetMachineUnits(self):
+        self.data.units = self.onEntryUnits #Return main screen to old units
         if self.data.units == "INCHES":
             self.data.gcode_queue.put('G20 ')
         else:

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -13,6 +13,7 @@ class ZAxisPopupContent(GridLayout):
     done   = ObjectProperty(None)
     zCutLabel = StringProperty("Re-Plunge To\nSaved Depth")
     zPopDisable = ObjectProperty(True)
+    onEntryUnits = StringProperty("")
     
     def initialize(self, zStepSizeVal):
         '''
@@ -21,6 +22,7 @@ class ZAxisPopupContent(GridLayout):
         
         '''
         self.unitsBtn.text = self.data.units
+        self.onEntryUnits = self.data.units
         self.distBtn.text  = str(zStepSizeVal)
         if self.data.zPush is not None:
             self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
@@ -138,9 +140,10 @@ class ZAxisPopupContent(GridLayout):
         Close The Pop-up to enter distance information
         
         '''
+        self.data.units=self.onEntryUnits #Restore original units
         try:
             tempfloat = float(self.popupContent.textInput.text)
             self.distBtn.text = str(tempfloat)  # Update displayed text using standard numeric format
         except:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
-        self._popup.dismiss()
+        self.done()

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -13,20 +13,20 @@ class ZAxisPopupContent(GridLayout):
     done   = ObjectProperty(None)
     zCutLabel = StringProperty("Re-Plunge To\nSaved Depth")
     zPopDisable = ObjectProperty(True)
-    onEntryUnits = StringProperty("")
+    unitsArmed=False
     
-    def initialize(self, zStepSizeVal):
+    def initialize(self):
         '''
         
         Initialize the z-axis popup
         
         '''
-        self.unitsBtn.text = self.data.units
-        self.onEntryUnits = self.data.units
-        self.distBtn.text  = str(zStepSizeVal)
+        if self.data.zPopupUnits is None:
+            self.data.zPopupUnits = self.data.units
+        self.unitsBtn.text = self.data.zPopupUnits
         if self.data.zPush is not None:
             self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
-            self.zPopDisable = self.data.zPushUnits <> self.data.units
+            self.zPopDisable = self.data.zPushUnits <> self.data.zPopupUnits
     
     def setDist(self):
         self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
@@ -37,19 +37,17 @@ class ZAxisPopupContent(GridLayout):
     
     def units(self):
         '''
-        
-        Toggle the machine units.
-        
+        Toggle the dialog units.
         '''
-        if self.data.units == "INCHES":
-            self.data.units = "MM"
-            self.distBtn.text = "{0:.2f}".format(25.4*float(self.distBtn.text))
+        if self.data.zPopupUnits == "INCHES":
+            self.data.zPopupUnits = "MM"
+            self.data.zStepSizeVal=25.4*float(self.distBtn.text)
         else:
-            self.data.units = "INCHES"
-            
-            self.distBtn.text = "{0:.2f}".format(float(self.distBtn.text)/25.4)
+            self.data.zPopupUnits = "INCHES"
+            self.data.zStepSizeVal=float(self.distBtn.text)/25.4
         
-        self.unitsBtn.text = self.data.units
+        self.distBtn.text = "%.2f"%self.data.zStepSizeVal
+        self.unitsBtn.text = self.data.zPopupUnits
         
         if self.data.zPush is not None:
             self.zPopDisable = self.data.zPushUnits <> self.data.units
@@ -140,14 +138,13 @@ class ZAxisPopupContent(GridLayout):
         Close The Pop-up to enter distance information
         
         '''
-        self.data.units=self.onEntryUnits #Restore original units
         try:
             tempfloat = float(self.popupContent.textInput.text)
-            self.distBtn.text = str(tempfloat)  # Update displayed text using standard numeric format
-        except:
+            self.data.zStepSizeVal=tempfloat  # Update displayed text using standard numeric format
+            self.distBtn.text = "%.2f"%tempfloat
+        except ValueError:
             pass                                                             #If what was entered cannot be converted to a number, leave the value the same
         self._popup.dismiss()
         
     def close(self):
-        self.data.units=self.onEntryUnits #Restore original units
         self.done()

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -11,7 +11,7 @@ from   kivy.uix.popup                            import   Popup
 
 class ZAxisPopupContent(GridLayout):
     done   = ObjectProperty(None)
-    zCutLabel = StringProperty("to...")
+    zCutLabel = StringProperty("[To Saved]")
     zPopDisable = ObjectProperty(True)
     
     def initialize(self, zStepSizeVal):
@@ -23,7 +23,7 @@ class ZAxisPopupContent(GridLayout):
         self.unitsBtn.text = self.data.units
         self.distBtn.text  = str(zStepSizeVal)
         if self.data.zPush is not None:
-            self.zCutLabel = "to:"+'%.2f'%(self.data.zPush)
+            self.zCutLabel = "To "+'%.2f'%(self.data.zPush)
             self.zPopDisable = self.data.zPushUnits <> self.data.units
     
     def setDist(self):

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -11,7 +11,7 @@ from   kivy.uix.popup                            import   Popup
 
 class ZAxisPopupContent(GridLayout):
     done   = ObjectProperty(None)
-    zCutLabel = StringProperty("[To Saved]")
+    zCutLabel = StringProperty("Re-Plunge To\nSaved Depth")
     zPopDisable = ObjectProperty(True)
     
     def initialize(self, zStepSizeVal):
@@ -23,7 +23,7 @@ class ZAxisPopupContent(GridLayout):
         self.unitsBtn.text = self.data.units
         self.distBtn.text  = str(zStepSizeVal)
         if self.data.zPush is not None:
-            self.zCutLabel = "To "+'%.2f'%(self.data.zPush)
+            self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
             self.zPopDisable = self.data.zPushUnits <> self.data.units
     
     def setDist(self):
@@ -81,8 +81,8 @@ class ZAxisPopupContent(GridLayout):
         '''
         #Save the current "cut" point
         self.data.zPush = self.data.zReadoutPos
-        self.data.zPushUnits = self.units
-        self.zCutLabel = "to:"+'%.2f'%(self.data.zPush)
+        self.data.zPushUnits = self.data.units
+        self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
         self.zPopDisable = False
         
         if self.data.units == "INCHES":

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -27,7 +27,20 @@ class ZAxisPopupContent(GridLayout):
         if self.data.zPush is not None:
             self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
             self.zPopDisable = self.data.zPushUnits <> self.data.zPopupUnits
-    
+        self.setMachineUnits()
+
+    def setMachineUnits(self):
+        if self.data.zPopupUnits == "INCHES":
+            self.data.gcode_queue.put('G20 ')
+        else:
+            self.data.gcode_queue.put('G21 ')
+
+    def resetMachineUnits(self):
+        if self.data.units == "INCHES":
+            self.data.gcode_queue.put('G20 ')
+        else:
+            self.data.gcode_queue.put('G21 ')
+
     def setDist(self):
         self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
         self._popup = Popup(title="Change increment size of machine movement", content=self.popupContent,
@@ -56,24 +69,26 @@ class ZAxisPopupContent(GridLayout):
         '''
         Go to the position (into work -- you can pop out to a safe height)
         '''
+        self.setMachineUnits()
         self.data.gcode_queue.put("G00 Z"+ str(-1*float(self.distBtn.text)))
+        self.resetMachineUnits()
         
     
     def zIn(self):
         '''
-        
         Move the z-axis in
-        
         '''
+        self.setMachineUnits()
         self.data.gcode_queue.put("G91 G00 Z" + str(-1*float(self.distBtn.text)) + " G90 ")
-    
+        self.resetMachineUnits()
+
     def zOut(self):
-        '''
-        
+        '''        
         Move the z-axis out
-        
         '''
+        self.setMachineUnits()
         self.data.gcode_queue.put("G91 G00 Z" + str(self.distBtn.text) + " G90 ")
+        self.resetMachineUnits()
         
     def zUp(self):
         '''
@@ -85,23 +100,26 @@ class ZAxisPopupContent(GridLayout):
         self.zCutLabel = "Re-Plunge to\n"+'%.2f'%(self.data.zPush)
         self.zPopDisable = False
         
-        if self.data.units == "INCHES":
+        self.setMachineUnits()
+        if self.data.zPopupUnits == "INCHES":
             self.data.gcode_queue.put("G00 Z.25 ")
         else:
             self.data.gcode_queue.put("G00 Z5.0 ")
+        self.resetMachineUnits()
 
     def zToZero(self):
         '''
         Move z-axis to zero
         '''
-        self.data.gcode_queue.put("G00 Z0")
+        self.data.gcode_queue.put("G00 Z0") #Zero is zero in mm or in ;)
         
     def zToCut(self):
         '''
         Move z-axis to last cut (saved point when "move to safety" was pressed
         '''
-        print "zspot", self.data.zPush
+        self.setMachineUnits()
         self.data.gcode_queue.put("G00 Z"+str(self.data.zPush))
+        self.resetMachineUnits()
     
     def zero(self):
         '''
@@ -115,17 +133,17 @@ class ZAxisPopupContent(GridLayout):
         '''
         Probe for Zero Z
         '''
+        self.setMachineUnits()
         if self.data.units == "INCHES":
             self.data.gcode_queue.put("G38.2 Z2 F2")    #Only go down 2 inches...
         else:
             self.data.gcode_queue.put("G38.2 Z50 F50")  #Or 50mm.
+        self.resetMachineUnits()
             
     
     def stopZMove(self):
         '''
-        
         Send the immediate stop command
-        
         '''
         print("z-axis Stopped")
         self.data.quick_queue.put("!")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -616,10 +616,12 @@
 				cols:1
 				rows:2
 				Button:
-					text: "To -"+root.distBtn.text
+					text: "Plunge to\n-"+root.distBtn.text
+					halign: "center"
 					on_release: root.goThere()
 				Button:
-					text: "To Safety"
+					text: "Save and\nRaise to Traverse"
+					halign: "center"
 					on_release: root.zUp()
             Button:
                 text: "Done"
@@ -642,10 +644,11 @@
 				cols:1
 				rows:2
 				Button:
-					text: "To Zero"
+					text: "Go to Zero"
 					on_release: root.zToZero()
 				Button:
 					text: root.zCutLabel
+					halign: "center"
 					disabled: root.zPopDisable
 					on_release: root.zToCut()
 			Label:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -616,7 +616,7 @@
 				cols:1
 				rows:2
 				Button:
-					text: "To Depth"
+					text: "To: -"+root.distBtn.text
 					on_release: root.goThere()
 				Button:
 					text: "To Safety"

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -153,6 +153,7 @@
                 funcToCallOnPress: root.downRight
             ButtonTemplate:
                 id: zAxisBtn
+				disabled: app.data.uploadFlag == 1 #zAxisPopup can change units... don't let it be popped during a move!
                 text: 'Z-Axis'
                 funcToCallOnPress: root.zAxisPopup
             Label:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -616,7 +616,7 @@
 				cols:1
 				rows:2
 				Button:
-					text: "To: -"+root.distBtn.text
+					text: "To -"+root.distBtn.text
 					on_release: root.goThere()
 				Button:
 					text: "To Safety"

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -602,7 +602,7 @@
 				text: "Absolute"
 				size_hint_y: 0.2
 			Button:
-				text: ".1"
+				text: "%.2f"%app.data.zStepSizeVal
 				id: distBtn
 				on_release: root.setDist()
             Button:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -589,27 +589,63 @@
         GridLayout:
             size_hint_x: ".75sp"
             cols: 3
-            rosw: 2
-            Button:
-                text: ".1"
-                id: distBtn
-                on_release: root.setDist()
+            rows: 2
+			GridLayout:
+				cols: 1
+				rows: 2
+				Button:
+					text: ".1"
+					id: distBtn
+					on_release: root.setDist()
+				Button:
+					size_hint_y:0.2
+					text: "ToDepth [Absolute]"
+					on_release: root.goThere()
             Button:
                 text: "MM"
                 on_release: root.units()
                 id: unitsBtn
-            Button:
-                text: "Raise"
-                on_release: root.zOut()
+			GridLayout:
+				cols:1
+				rows:2
+				Button:
+					text: "Raise"
+					on_release: root.zOut()
+				Button:
+					size_hint_y: 0.2
+					text: "to safety"
+					on_release: root.zUp()
             Button:
                 text: "Done"
                 on_release: root.done()
-            Button:
-                text: "Define Zero"
-                on_release: root.zero()
-            Button:
-                text: "Lower"
-                on_release: root.zIn()
+			GridLayout:
+				cols: 1
+				rows: 2
+				Button:
+					text: "Define Zero"
+					on_release: root.zero()
+				Button:
+					size_hint_y: 0.2
+					text: "Touch Zero"
+					on_release: root.touchZero()
+					disabled: True
+			GridLayout:
+				cols:1
+				rows:2
+				Button:
+					text: "Lower"
+					on_release: root.zIn()
+				GridLayout:
+					size_hint_y: 0.2
+					cols:2
+					rows:1
+					Button:
+						text: "to Zero"
+						on_release: root.zToZero()
+					Button:
+						text: root.zCutLabel
+						disabled: root.zPopDisable
+						on_release: root.zToCut()
         GridLayout:
             size_hint_x: ".25sp"
             cols: 1

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -585,36 +585,30 @@
     size: root.size
     pos: root.pos
     GridLayout:
-        cols: 2
+        cols: 3
         GridLayout:
             size_hint_x: ".75sp"
             cols: 3
-            rows: 2
-			GridLayout:
-				cols: 1
-				rows: 2
-				Button:
-					text: ".1"
-					id: distBtn
-					on_release: root.setDist()
-				Button:
-					size_hint_y:0.2
-					text: "ToDepth [Absolute]"
-					on_release: root.goThere()
+            rows: 3
+			Label:
+				text: ""
+				size_hint_y: 0.2
+			Label:
+				size_hint_y: 0.2
+			Label:
+				text: "Relative"
+				size_hint_y: 0.2
+			Button:
+				text: ".1"
+				id: distBtn
+				on_release: root.setDist()
             Button:
                 text: "MM"
                 on_release: root.units()
                 id: unitsBtn
-			GridLayout:
-				cols:1
-				rows:2
-				Button:
-					text: "Raise"
-					on_release: root.zOut()
-				Button:
-					size_hint_y: 0.2
-					text: "to safety"
-					on_release: root.zUp()
+			Button:
+				text: "Raise"
+				on_release: root.zOut()
             Button:
                 text: "Done"
                 on_release: root.done()
@@ -629,32 +623,44 @@
 					text: "Touch Zero"
 					on_release: root.touchZero()
 					disabled: True
-			GridLayout:
-				cols:1
-				rows:2
-				Button:
-					text: "Lower"
-					on_release: root.zIn()
-				GridLayout:
-					size_hint_y: 0.2
-					cols:2
-					rows:1
-					Button:
-						text: "to Zero"
-						on_release: root.zToZero()
-					Button:
-						text: root.zCutLabel
-						disabled: root.zPopDisable
-						on_release: root.zToCut()
+			Button:
+				text: "Lower"
+				on_release: root.zIn()
         GridLayout:
             size_hint_x: ".25sp"
             cols: 1
-            rosw: 1
+            rows: 1
             Button:
                 text: "Stop!"
                 # font_size: '48sp'
                 # color: [1,0,0,1]
                 on_release: root.stopZMove()
+		GridLayout:
+			cols: 1
+			rows: 3
+			size_hint_x: ".25sp"
+			Label:
+				text: "Absolute"
+				size_hint_y: 0.2
+			GridLayout:
+				cols:1
+				rows:2
+				Button:
+					text: "To Depth"
+					on_release: root.goThere()
+				Button:
+					text: "To Safety"
+					on_release: root.zUp()
+			GridLayout:
+				cols:1
+				rows:2
+				Button:
+					text: "To Zero"
+					on_release: root.zToZero()
+				Button:
+					text: root.zCutLabel
+					disabled: root.zPopDisable
+					on_release: root.zToCut()
 
 <TriangularCalibration>:
     cutBtnT:cutBtnT

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -589,7 +589,7 @@
         GridLayout:
             size_hint_x: ".75sp"
             cols: 4
-            rows: 3
+            rows: 4
 			Label:
 				text: ""
 				size_hint_y: 0.2
@@ -648,6 +648,9 @@
 					text: root.zCutLabel
 					disabled: root.zPopDisable
 					on_release: root.zToCut()
+			Label:
+				text: ""
+				size_hint_y: 0.2
         GridLayout:
             size_hint_x: ".25sp"
             cols: 1

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -588,7 +588,7 @@
         cols: 3
         GridLayout:
             size_hint_x: ".75sp"
-            cols: 3
+            cols: 4
             rows: 3
 			Label:
 				text: ""
@@ -597,6 +597,9 @@
 				size_hint_y: 0.2
 			Label:
 				text: "Relative"
+				size_hint_y: 0.2
+			Label:
+				text: "Absolute"
 				size_hint_y: 0.2
 			Button:
 				text: ".1"
@@ -609,6 +612,15 @@
 			Button:
 				text: "Raise"
 				on_release: root.zOut()
+			GridLayout:
+				cols:1
+				rows:2
+				Button:
+					text: "To Depth"
+					on_release: root.goThere()
+				Button:
+					text: "To Safety"
+					on_release: root.zUp()
             Button:
                 text: "Done"
                 on_release: root.done()
@@ -626,31 +638,6 @@
 			Button:
 				text: "Lower"
 				on_release: root.zIn()
-        GridLayout:
-            size_hint_x: ".25sp"
-            cols: 1
-            rows: 1
-            Button:
-                text: "Stop!"
-                # font_size: '48sp'
-                # color: [1,0,0,1]
-                on_release: root.stopZMove()
-		GridLayout:
-			cols: 1
-			rows: 3
-			size_hint_x: ".25sp"
-			Label:
-				text: "Absolute"
-				size_hint_y: 0.2
-			GridLayout:
-				cols:1
-				rows:2
-				Button:
-					text: "To Depth"
-					on_release: root.goThere()
-				Button:
-					text: "To Safety"
-					on_release: root.zUp()
 			GridLayout:
 				cols:1
 				rows:2
@@ -661,6 +648,15 @@
 					text: root.zCutLabel
 					disabled: root.zPopDisable
 					on_release: root.zToCut()
+        GridLayout:
+            size_hint_x: ".25sp"
+            cols: 1
+            rows: 1
+            Button:
+                text: "Stop!"
+                # font_size: '48sp'
+                # color: [1,0,0,1]
+                on_release: root.stopZMove()
 
 <TriangularCalibration>:
     cutBtnT:cutBtnT

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -625,7 +625,7 @@
 					on_release: root.zUp()
             Button:
                 text: "Done"
-                on_release: root.dismiss_popup()
+                on_release: root.close()
 			GridLayout:
 				cols: 1
 				rows: 2

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -620,12 +620,12 @@
 					halign: "center"
 					on_release: root.goThere()
 				Button:
-					text: "Save and\nRaise to Traverse"
+					text: "Save and\nRaise to\nTraverse"
 					halign: "center"
 					on_release: root.zUp()
             Button:
                 text: "Done"
-                on_release: root.done()
+                on_release: root.dismiss_popup()
 			GridLayout:
 				cols: 1
 				rows: 2

--- a/main.py
+++ b/main.py
@@ -766,11 +766,12 @@ class GroundControlApp(App):
             if math.isnan(self.zval):
                 self.writeToTextConsole("Unable to resolve z Kinematics.")
                 self.zval = 0
-            self.frontpage.setPosReadout(self.xval, self.yval, self.zval)
-            self.frontpage.gcodecanvas.positionIndicator.setPos(self.xval,self.yval,self.data.units)
         except:
             print "One Machine Position Report Command Misread"
             return
+
+        self.frontpage.setPosReadout(self.xval, self.yval, self.zval)
+        self.frontpage.gcodecanvas.positionIndicator.setPos(self.xval,self.yval,self.data.units)
     
     def setErrorOnScreen(self, message):
         


### PR DESCRIPTION
So now you can:
  move in absolute terms, 
  jump to the safe height
  jump back to the height you were before the safe height
  jump to zero
  probe for Z-Zero (disabled because there should be a flag/instructions on how to hook that up

Questions:
  1. Should the Z-Zero Probe be in "Measure Machine" (I suppose I was calling it "Setup Machine"
  2. Should the Home button go to Z-Zero?  I know canonically that it should, but if you left it at Z-Safe, there'd be one less prompt for manual Z users (and no touchmarks at 0 for automated z users)?
  3. Is there any interest in an "AirCutting" Flag -- when set, the firmware will ignore all Z changes, but will traverse the paths?  On this dialog, it could be a "Mode: Auto, Manual, Ignored" bit.
  3b. One use I have for it is "oh... it would be cool to add a trench between these 2 points - 
      Pause
      Use G-Code navigator to go to start
      Go
      Pause
      Z-Popup: Go to .25" depth, Set Mode=Ignored, Done
      Resume (cut trench)
      Pause (during cut)
       ...wait for cut....
      Z-Popup: Go to Safe, Set Mode=Auto, Done
      Resume Job

FWIW.... might be an obtuse scenario...