### PR TITLE
add Advanced setting for PWM frequency

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -327,6 +327,14 @@ settings = {
                 "desc": "The derivative constant for the velocity PID controller",
                 "key": "KdV",
                 "default": .28
+            },
+            {
+                "type": "options",
+                "title": "PWM frequency for motor control",
+                "desc": "The PWM frequence used for motor speed control",
+                "options": ["490Hz", "4,100Hz", "31,000Hz"],
+                "default": "490Hz",
+                "key": "fPWM",
             }
         ],
     "Ground Control Settings":
@@ -446,6 +454,11 @@ settings = {
                 "type": "string",
                 "key": "chainOverSprocketComputed",
                 "firmwareKey": 38
+            },
+            {
+                "type": "string",
+                "key": "fPWMComputed",
+                "firmwareKey": 39
             }
         ]
 }

--- a/main.py
+++ b/main.py
@@ -182,6 +182,14 @@ class GroundControlApp(App):
             else:
                 self.config.set('Computed Settings',  'chainOverSprocketComputed', 2)
 
+        elif key == 'fPWM':
+            if value == '31,000Hz':
+                self.config.set('Computed Settings',  'fPWMComputed', 1)
+            elif value == '4,100Hz':
+                self.config.set('Computed Settings',  'fPWMComputed', 2)
+            else: 
+                self.config.set('Computed Settings',  'fPWMComputed', 3)
+
     def configSettingChange(self, section, key, value):
         """
         Respond to changes in the configuration.


### PR DESCRIPTION
This builds on Firmware PRs 385, 386 and 389 (all required) to allow changing the PWM prescale frequency from within the Advanced settings.

It offers three choices:
490Hz  ($39=3)
4,100Hz  ($39=2)
31,000Hz  ($39=1)

Note, the $39 values directly correspond to the values used in the firmware System.cpp:setPWMPrescalers()