### PR TITLE
Include note requiring restart

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -183,7 +183,7 @@ settings = {
             },
             {
                 "type": "options",
-                "title": "Side of Motor Sprockets That Chains Go to Sled",
+                "title": "Side of Motor Sprockets That Chains Go to Sled (Requires Maslow Board Restart)",
                 "desc": "On which side of the motor sprockets the chains connect to the sled",
                 "options": ["Top", "Bottom"],
                 "default": "Top",


### PR DESCRIPTION
Include note that changing the setting for the chain wrapping on the top or bottom of the sprockets will require the Maslow board to be restarted.

I'm still working through some of the recent changes, so I haven't been able to get a more descriptive pop-up screen done. But this at least notifies the user that a restart is required.