### PR TITLE
Add a try...except catch to velocity calculation

### DIFF
--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -124,8 +124,11 @@ class FrontPage(Screen, MakesmithInitFuncs):
         if self.tick>=4:    #Can't do this every time... it's too noisy, so we do it every 5rd time (0.1s).
             self.tick=0
             if self.lasttime <> 0.0:
-                delta = sqrt( (xPos-self.lastpos[0])*(xPos-self.lastpos[0]) + (yPos-self.lastpos[1])*(yPos-self.lastpos[1]) + (zPos-self.lastpos[2]) * (zPos-self.lastpos[2]))
-                Vel = delta / (time()-self.lasttime) * 60.0 #In XXXX/minute
+				try:
+					delta = sqrt( (xPos-self.lastpos[0])*(xPos-self.lastpos[0]) + (yPos-self.lastpos[1])*(yPos-self.lastpos[1]) + (zPos-self.lastpos[2]) * (zPos-self.lastpos[2]))
+					Vel = delta / (time()-self.lasttime) * 60.0 #In XXXX/minute
+				except:
+					print "unable to compute velocity"
             else:
                 Vel=0
                 


### PR DESCRIPTION
Sometimes this line is failing with a division by zero error...probably because time() is the same as self.lasttime

This could be because the value of last time didn't update properly somewhere or because the function was called back to back and something went wrong on the OS side.

The proposed solution here is to just ignore it when that happens and don't update the velocity for that command.

It's not super elegant.