### PR TITLE
Add setting for Z-Axis Safe Travel

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -155,6 +155,13 @@ settings = {
                 "desc": "User defined title for the Macro 2 button",
                 "key": "macro2_title",
                 "default": "Macro 2"
+            },
+            {
+                "type": "string",
+                "title": "Z-Axis Safe Travel Height in MM",
+                "desc": "The vertical distance above the work area to raise the z-axis for safe travel. Used by 'Home', 'Return to Center' and 'z-Axis' settings.",
+                "key": "zAxisSafeHeight",
+                "default": 5,
             }
         ],
     "Advanced Settings":

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -340,10 +340,12 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.data.gcode_queue.put("G90  ")
         self.gcodeVel = "[MAN]"
         
-        if self.units == "INCHES":
-            self.data.gcode_queue.put("G00 Z.25 ")
+        safeHeightMM = float(self.data.config.get('Maslow Settings', 'zAxisSafeHeight'))
+        safeHeightInches = safeHeightMM / 25.5
+        if self.data.units == "INCHES":
+            self.data.gcode_queue.put("G00 Z" + '%.3f'%(safeHeightInches))
         else:
-            self.data.gcode_queue.put("G00 Z5.0 ")
+            self.data.gcode_queue.put("G00 Z" + str(safeHeightMM))
         
         self.data.gcode_queue.put("G00 X" + str(self.data.gcodeShift[0]) + " Y" + str(self.data.gcodeShift[1]) + " ")
         

--- a/UIElements/runMenu.py
+++ b/UIElements/runMenu.py
@@ -15,10 +15,12 @@ class RunMenu(FloatLayout):
         
         self.data.gcode_queue.put("G90  ")
         
+        safeHeightMM = float(self.data.config.get('Maslow Settings', 'zAxisSafeHeight'))
+        safeHeightInches = safeHeightMM / 25.5
         if self.data.units == "INCHES":
-            self.data.gcode_queue.put("G00 Z.25 ")
+            self.data.gcode_queue.put("G00 Z" + '%.3f'%(safeHeightInches))
         else:
-            self.data.gcode_queue.put("G00 Z5.0 ")
+            self.data.gcode_queue.put("G00 Z" + str(safeHeightMM))
         
         self.data.gcode_queue.put("G00 X0.0 Y0.0 ")
             

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -104,10 +104,12 @@ class ZAxisPopupContent(GridLayout):
         self.zPopDisable = False
         
         self.setMachineUnits()
-        if self.data.zPopupUnits == "INCHES":
-            self.data.gcode_queue.put("G00 Z.25 ")
+        safeHeightMM = float(self.data.config.get('Maslow Settings', 'zAxisSafeHeight'))
+        safeHeightInches = safeHeightMM / 25.5
+        if self.data.units == "INCHES":
+            self.data.gcode_queue.put("G00 Z" + '%.3f'%(safeHeightInches))
         else:
-            self.data.gcode_queue.put("G00 Z5.0 ")
+            self.data.gcode_queue.put("G00 Z" + str(safeHeightMM))
         self.resetMachineUnits()
 
     def zToZero(self):


### PR DESCRIPTION
Currently, the ‘Home’ button, ‘Return to Center’ button and Z-Axis popup 'Save and Raise to Traverse' button in GC have hard-coded values for safe travel.
Add a value to maslowSettings.py in the 'Maslow Settings' section to let the user choose the value and save it between launches.
 This PR follows the convention for the Settings page and uses 'mm' for the units entered and recorded.
 See Issue #629.