### PR TITLE
Limit the Z axis travel of the G38.2 code

### DIFF
--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -140,9 +140,9 @@ class ZAxisPopupContent(GridLayout):
         '''
         self.setMachineUnits()
         if self.data.units == "INCHES":
-            self.data.gcode_queue.put("G38.2 Z2 F2")    #Only go down 2 inches...
+            self.data.gcode_queue.put("G38.2 Z-.2 F2")    #Only go down 0.2 inches...
         else:
-            self.data.gcode_queue.put("G38.2 Z50 F50")  #Or 50mm.
+            self.data.gcode_queue.put("G38.2 Z-.5 F50")  #Or 0.5mm.
         self.resetMachineUnits()
             
     


### PR DESCRIPTION
The G38.2 code is designed to accept a negative Z parameter which defines the limit to which the Z axis will probe before cancelling the action. It is important that the G38.2 command not drive the Z axis beyond the physical limits of the machine and the Z parameter helps prevent this.
The intended process is for the user to manually move the Z axis near to the surface and set that starting point as zero, then issue the G38.2 command to probe for the surface. If the probe does not touch before reaching the limit defined by the Z parameter, the command fails. If the probe touches the surface, that location becomes the Z-axis zero point.