### PR TITLE
Stretch text console to full window height

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -109,7 +109,7 @@
         id: gcodecanvas
     BoxLayout:
         orientation: 'vertical'
-        pos: root.width - dp(300), root.height - dp(630)
+        pos: root.width - dp(300), dp(0)
         GridLayout:
             cols: 4
             size_hint: None, None
@@ -273,7 +273,7 @@
             color: .476, .476, .476,1
         ScrollableLabel:
             id: textconsole
-            size: dp(300), dp(200)
+            size: dp(300), root.height - dp(430)
             text: root.consoleText
             size_hint: None, None
 

--- a/main.py
+++ b/main.py
@@ -267,7 +267,7 @@ class GroundControlApp(App):
     
     def writeToTextConsole(self, message):
         try:
-            newText = self.frontpage.consoleText[-500:] + message
+            newText = self.frontpage.consoleText[-2000:] + message
             self.frontpage.consoleText = newText
             self.frontpage.textconsole.gotToBottom()  
         except:


### PR DESCRIPTION
Changes to permit to scrolling back in the textConsole portion of the frontPage window to look at more of the earlier lines.
- Stretch the textConsole portion of the window so that it uses the full distance from its current position to the bottom of the window, and
- change the way it is updated to preserve 2000 characters? instead of just 500.
Addresses issue #628 