### PR TITLE
rename 'zAxisAuto' to 'spindleAutomate'

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -215,7 +215,7 @@ settings = {
             {
                 "type": "bool",
                 "title": "Spindle Automation",
-                "desc": "Should the spindle start and stop automatically based on gcode? Leave off for default stepper control.",
+                "desc": "How should the spindle start and stop automatically based on gcode? Leave off for default external servo control, on for external relay control.",
                 "key": "spindleAutomate",
                 "default": 0,
                 "firmwareKey": 17

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -216,7 +216,7 @@ settings = {
                 "type": "bool",
                 "title": "Spindle Automation",
                 "desc": "Should the spindle start and stop automatically based on gcode? Leave off for default stepper control.",
-                "key": "zAxisAuto",
+                "key": "spindleAutomate",
                 "default": 0,
                 "firmwareKey": 17
             },


### PR DESCRIPTION
PR #458 added a setting to enable/disable spindle control. The setting was named 'zAxisAuto' which seems confusing as it is being used as an on/off control for spindle power. Change the name to 'spindleAutomation' to better reflect its use. Note that the change in GC will match an accompanying PR in Firmware.

This accompanies Firmware PR #392