### PR TITLE
Make Maslow traverse to target safely when jumping through g-code

### DIFF
--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -33,6 +33,8 @@ class Data(EventDispatcher):
     comport    = StringProperty("")
     #The index of the next unread line of Gcode
     gcodeIndex = NumericProperty(0)
+    #Flag for a Gcode jump
+    gcodeJump= BooleanProperty(False)
     #Index of changes in z
     zMoves     = ObjectProperty([])
     #Holds the current value of the feed rate

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -230,8 +230,10 @@ class FrontPage(Screen, MakesmithInitFuncs):
             self.data.gcodeIndex = maxIndex
         else:
             self.data.gcodeIndex = targetIndex
+        self.data.gcodeJump=True;
         
         gCodeLine = self.data.gcode[self.data.gcodeIndex]
+        
         
         xTarget = 0
         yTarget = 0

--- a/main.py
+++ b/main.py
@@ -415,8 +415,9 @@ class GroundControlApp(App):
             
             self.frontpage.gcodecanvas.positionIndicator.setError(0, self.data.units)
             self.data.logger.writeErrorValueToLog(avgError)
-            
-            self.frontpage.gcodecanvas.targetIndicator.setPos(self.xval - .5*rightErrorValueAsFloat + .5*leftErrorValueAsFloat, self.yval - .5*rightErrorValueAsFloat - .5*leftErrorValueAsFloat,self.data.units)
+
+            if not self.data.gcodeJump:
+                self.frontpage.gcodecanvas.targetIndicator.setPos(self.xval - .5*rightErrorValueAsFloat + .5*leftErrorValueAsFloat, self.yval - .5*rightErrorValueAsFloat - .5*leftErrorValueAsFloat,self.data.units)
             
             
         except:


### PR DESCRIPTION
**Needs to be tested**, written AFM.
But this should fix issue #612 and make jumping around in g-code much safer.

BUT.  If you press *stop*, the 2 commands that I stuffed into the buffer are lost in the sea of nothingness.   Pressing Stop and then Go will probably put you in a bad place...
