### PR TITLE
Update calibration buttons names to be more clear

### DIFF
--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -113,7 +113,7 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         
         if   text == "Test Feedback System":
             self.testFeedbackSystem()
-        elif text == "Calibrate Chain Length - Manual":
+        elif text == "Set Chain Length - Manual":
             self.manualCalibrateChainLengths()
         elif text == "Wipe EEPROM":
             self.wipeEEPROM()

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -371,14 +371,13 @@
                 text: 'Test Motors/Encoders'
                 on_press: root.testMotors()
             Button:
-                text: 'Calibrate Machine Dimensions'
+                text: 'Calibrate'
                 on_release: root.measureMachine()
             Button:
-                text: 'Calibrate Chain Length - Automatic'
+                text: 'Set Chain Length - Automatic'
                 on_release: root.calibrateChainLengths()
             Button:
-                text: 'Calibrate Motors\n-----Obsolete-----'
-                on_release: root.calibrateMotors()
+                text: ' '
                 disabled: True
             Button:
                 text: 'About'
@@ -387,7 +386,7 @@
             Spinner:
                 id: advancedOptions
                 text: "Advanced"
-                values: ["Calibrate Chain Length - Manual", "Wipe EEPROM", "Simulation", "Load Calibration Benchmark Test"]
+                values: ["Set Chain Length - Manual", "Wipe EEPROM", "Simulation", "Load Calibration Benchmark Test"]
                 on_text: root.advancedOptionsFunctions(advancedOptions.text)
 
 <OtherFeatures>:


### PR DESCRIPTION
The buttons to launch the calibrations and set the chain lengths are poorly named as described in this forum thread:

https://forums.maslowcnc.com/t/wheres-the-calibration-page/2386

This PR updates the names to be more clear by changing the calibrate button to just say "calibrate" and the set chain lengths buttons to say "set chain lengths"

![image](https://user-images.githubusercontent.com/9359447/36443774-8367d17e-162e-11e8-897f-ec54d09f4e52.png)
