### PR TITLE
Combined/revised patch for Load Image on Background

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -151,7 +151,13 @@ class SerialPortThread(MakesmithInitFuncs):
                 #Send the next line of gcode to the machine if we're running a program
                 if self.bufferSpace == self.bufferSize and self.machineIsReadyForData: #> len(self.data.gcode[self.data.gcodeIndex]):
                     if self.data.uploadFlag:
-                        self._write(self.data.gcode[self.data.gcodeIndex])
+                        #Skip blank lines
+                        while self.data.gcode[self.data.gcodeIndex].isspace() and self.data.gcodeIndex < len(self.data.gcode):
+                            self.data.gcodeIndex = self.data.gcodeIndex + 1
+                         
+                        #Make sure we didn't fall off the end!
+                        if self.data.gcodeIndex <= len(self.data.gcode):
+                            self._write(self.data.gcode[self.data.gcodeIndex])
                         
                         #increment gcode index
                         if self.data.gcodeIndex + 1 < len(self.data.gcode):

--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -26,6 +26,10 @@ class Data(EventDispatcher):
     
     #Gcodes contains all of the lines of gcode in the opened file
     gcode      = ObjectProperty([])
+    gcodeOriginal  = StringProperty("")     #Raw file from disk
+    
+    gcodeRedraw = BooleanProperty(False)    #Signal to redraw the g-code from buffers
+    
     version    = '1.07'
     #all of the available COM ports
     comPorts   = []
@@ -46,7 +50,14 @@ class Data(EventDispatcher):
     tolerance  = NumericProperty(0.5)
     gcodeShift = ObjectProperty([0.0,0.0])                          #the amount that the gcode has been shifted
     logger     =  Logger()                                          #the module which records the machines behavior to review later
-    
+
+    #Background image stuff
+    #Persist, No save:
+    backgroundImage = None  #CV2 images for the textures - marked
+    originalimage = None    #and original
+    backgroundLastFile = StringProperty("") #Last file loaded for the background
+    backgroundClock = None                  #And a saver for the Periodic Update clock.
+
     '''
     Flags
     '''

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -375,7 +375,7 @@ settings = {
                 "default": ".nc, .ngc, .text, .gcode"
             }
         ],
-    "Computed Settings": #These are setting calculated from the user inputs on other settings, they are not direclty seen by the user
+    "Computed Settings": #These are setting calculated from the user inputs on other settings, they are not directly seen by the user
         [
             {
                 "type": "string",
@@ -466,6 +466,71 @@ settings = {
                 "type": "string",
                 "key": "fPWMComputed",
                 "firmwareKey": 39
+            }
+        ],
+    "Background Settings": #These settings are used by the BackgroundImage routines
+        [
+            {
+                "type": "string",
+                "title": "Background File or Directory",
+                "desc": "Last background file (or a directory, indicating 'latest here'.",
+                "key": "backgroundFile",
+                "default": ""
+            },
+            {
+                "type": "list",
+                "title": "TL Position",
+                "desc": "Top Left Position from 0,0 in mm.",
+                "key": "TLPos",
+                "default": (-1225, 615),
+            },
+            {
+                "type": "list",
+                "title": "TR Position",
+                "desc": "Top Right Position from 0,0 in mm.",
+                "key": "TLPos",
+                "default": (1225, 615),
+            },            {
+                "type": "list",
+                "title": "BL Position",
+                "desc": "Bottom Left Position from 0,0 in mm.",
+                "key": "BLPos",
+                "default": (-1225, -615),
+            },            
+            {
+                "type": "list",
+                "title": "BR Position",
+                "desc": "Bottom Right Position from 0,0 in mm.",
+                "key": "BRPos",
+                "default": (1225, -615),
+            },
+            {
+                "type": "list",
+                "title": "TL HSV",
+                "desc": "Top-Left HSV Interval.",
+                "key": "TLHSV",
+                "default": [(30,40,80),(90,255,255)],
+            },
+            {
+                "type": "list",
+                "title": "TR HSV",
+                "desc": "Top-Right HSV Interval.",
+                "key": "TRHSV",
+                "default": [(160, 60, 40),(10,255,255)],
+            },
+            {
+                "type": "list",
+                "title": "BL HSV",
+                "desc": "Bottom-Left HSV Interval.",
+                "key": "BLHSV",
+                "default": [(90,60,80),(140,255,255)],
+            },
+            {
+                "type": "list",
+                "title": "BR HSV",
+                "desc": "Bottom-Right HSV Interval.",
+                "key": "BRHSV",
+                "default": [(160, 60, 40),(10,255,255)],
             }
         ]
 }

--- a/UIElements/BackgroundPickDlg.py
+++ b/UIElements/BackgroundPickDlg.py
@@ -1,0 +1,111 @@
+from   kivy.uix.gridlayout                       import   GridLayout
+from   kivy.properties                           import   ObjectProperty
+from   kivy.properties                           import   StringProperty
+from   kivy.graphics.texture                     import Texture
+from   kivy.graphics							 import Rectangle
+from   kivy.clock                                import Clock
+from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
+
+
+import cv2
+import numpy as np
+
+class BackgroundPickDlg(GridLayout, MakesmithInitFuncs):
+    instructionText = StringProperty("Pickem")
+    armed = False
+    
+    def __init__(self, data, **kwargs):
+        super(BackgroundPickDlg, self).__init__(**kwargs)
+        self.data = data
+        self.centers=[]
+         
+        #Load the texture
+        self.instructionText = "Pick the Top-Left Alignment Dot"
+        self.img = self.data.backgroundImage.copy()
+        self.h = self.img.shape[0]
+        self.w = self.img.shape[1]
+        
+        self.texture = Texture.create(size=(self.w,self.h))   #Create Texture (only needs to be done once; blit to it as much as you like.
+        
+        #ToDo: I don't know why I can't simply say self.Drawing here, but it explodes
+        #So instead, I look for an object with the text 'Foo'
+        self.Drawing = None
+        for widget in self.walk():
+            try:
+                if widget.text == 'Foo':
+                    self.Drawing=widget
+            except (AttributeError):
+                pass
+
+        self.Drawing.bind(on_touch_down=self.touched)
+        self.Drawing.bind(on_touch_move=self.touchmove)
+        self.Drawing.bind(on_touch_up=self.untouched)
+        
+        #Can't draw yet... we're not on screen!
+        Clock.schedule_once(self.redraw)
+        
+    def redraw(self, *args):
+        print "Redraw:", self.centers
+        self.instructionText = [
+            "Pick the Top-Left Alignment Dot...", 
+            "Pick the Top-Right Alignment Dot...", 
+            "Pick the Bottom-Left Alignment Dot...", 
+            "Pick the Bottom-Right Alignment Dot."][len(self.centers)]
+
+        buf = self.img.tobytes() # then, convert the array to a ubyte string
+        self.texture.blit_buffer(buf, colorfmt='bgr', bufferfmt='ubyte') # and blit the buffer -- note that OpenCV format is BGR
+        self.texture.flip_vertical() #OpenGL is upside down...
+
+        #print self.Drawing
+        with self.Drawing.canvas:
+            Rectangle(texture=self.texture, pos=self.Drawing.pos, size=self.Drawing.size)
+            pass
+    
+    def clear(self):
+        #clear the list
+        self.centers=[]
+        
+        #present the original image
+        self.texture.flip_vertical()
+        self.img=self.data.backgroundImage.copy()
+        self.redraw()
+
+    def closeit(self):
+        self.close(self)
+    
+    def untouched(self, isntance, touch):
+        if not self.armed:
+            return 1
+            
+        self.armed=False
+            
+        #ToDo... Maybe I should use a scatter to do these transformations?
+        #Get canvas zero and size, since touch comes back to us in absolute screen coordinates
+        x0 = self.Drawing.pos[0]
+        y0 = self.Drawing.pos[1]
+        sx = self.Drawing.size[0]
+        sy = self.Drawing.size[1]
+        
+        if touch.x < x0 or touch.x > x0+sx or touch.y > y0+sy or touch.y < y0:
+            return 1    #Outside our bounding box!
+
+        #Yes, this is goofy, but it works:  Y is backwards
+        x = (touch.x-x0)/sx * self.w
+        y = (sy-(touch.y-y0))/sy * self.h
+
+        center = (int(x), int(y))
+        self.centers.append(center)
+        self.texture.flip_vertical()
+        cv2.circle(self.img, center, 25, (255, 255, 0), -1) #Cyan
+        if len(self.centers) < 4:
+            self.redraw()
+        else:
+            self.texture.flip_vertical()    #I was supposed to be working with a copy... why should I need to do this?!
+            self.close(self)                #All points picked, return to caller
+        
+    #ToDo: OnTouch/OnMove, pop-up a magnified thing so you can see crosshairs
+    def touched(self, isntance,  touch):
+        self.armed=True
+        
+    def touchmove(self, isntance, touch):
+        pass

--- a/UIElements/BackgroundSettingsDlg.py
+++ b/UIElements/BackgroundSettingsDlg.py
@@ -1,0 +1,43 @@
+from   kivy.uix.gridlayout                       import   GridLayout
+from   kivy.properties                           import   ObjectProperty
+from   kivy.properties                           import   StringProperty
+from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
+from   kivy.clock                                import Clock
+import json
+
+class BackgroundSettingsDlg(GridLayout, MakesmithInitFuncs):
+    backgroundTLHSV = StringProperty("[(30,40,80),(90,255,255)]")
+    backgroundTRHSV = StringProperty("[(160, 60, 40),(10,255,255)]")
+    backgroundBLHSV = StringProperty("[(90,60,80),(140,255,255)]")
+    backgroundBRHSV = StringProperty("[(160, 60, 40),(10,255,255)]")
+    backgroundTRPOS = StringProperty("( 1225, 615)")
+    backgroundTLPOS = StringProperty("(-1225, 615)")
+    backgroundBLPOS = StringProperty("(-1225,-615)")
+    backgroundBRPOS = StringProperty("( 1225,-615)")
+    
+    def __init__(self, parent, **kwargs):
+        super(BackgroundSettingsDlg, self).__init__(**kwargs)
+
+        #Convert to JSON data so caller can get tuples back
+        self.backgroundTLHSV = json.dumps(parent.backgroundTLHSV)
+        self.backgroundTRHSV = json.dumps(parent.backgroundTRHSV)
+        self.backgroundBLHSV = json.dumps(parent.backgroundBLHSV)
+        self.backgroundBRHSV = json.dumps(parent.backgroundBRHSV)
+        self.backgroundTRPOS = json.dumps(parent.data.backgroundTRPOS)
+        self.backgroundTLPOS = json.dumps(parent.data.backgroundTLPOS)
+        self.backgroundBLPOS = json.dumps(parent.data.backgroundBLPOS)
+        self.backgroundBRPOS = json.dumps(parent.data.backgroundBRPOS)
+        
+    def closeit(self):
+        #ToDo: Not sure why I have to copy all this back, but I do:
+        self.backgroundTLHSV = self.tlhsv.text
+        self.backgroundTRHSV = self.trhsv.text
+        self.backgroundBLHSV = self.blhsv.text
+        self.backgroundBRHSV = self.brhsv.text
+        self.backgroundTRPOS = self.trpos.text
+        self.backgroundTLPOS = self.tlpos.text
+        self.backgroundBLPOS = self.blpos.text
+        self.backgroundBRPOS = self.brpos.text
+        
+        self.close(self) #Call the callback
+        

--- a/UIElements/backgroundMenu.py
+++ b/UIElements/backgroundMenu.py
@@ -1,0 +1,331 @@
+from   kivy.uix.gridlayout                       import   GridLayout
+from   UIElements.fileBrowser                    import   FileBrowser
+from   UIElements.pageableTextPopup              import   PageableTextPopup
+from   kivy.uix.popup                            import   Popup
+from   kivy.clock                                import   Clock
+
+from DataStructures.makesmithInitFuncs           import MakesmithInitFuncs
+from UIElements.BackgroundPickDlg                import BackgroundPickDlg
+from UIElements.BackgroundSettingsDlg            import BackgroundSettingsDlg
+import os
+import cv2
+import numpy as np
+import json
+
+graphicsExtensions = (".jpg", ".png", ".jp2",".webp",".pbm",".ppm",".pgm")
+
+
+
+
+class BackgroundMenu(GridLayout, MakesmithInitFuncs):
+    
+    backgroundFile = ""
+    backgroundTLHSV = None
+    backgroundTRHSV = None
+    backgroundBLHSV = None
+    backgroundBRHSV = None
+    
+    
+    def __init__(self, data, **kwargs):
+        super(BackgroundMenu, self).__init__(**kwargs)
+        self.data = data
+        
+        #Load the data from the config file 
+        self.backgroundFile = self.data.config.get('Background Settings', 'backgroundFile')
+        self.backgroundTLHSV = json.loads(self.data.config.get('Background Settings', 'backgroundTLHSV'))
+        self.backgroundTRHSV = json.loads(self.data.config.get('Background Settings', 'backgroundTRHSV'))
+        self.backgroundBLHSV = json.loads(self.data.config.get('Background Settings', 'backgroundBLHSV'))
+        self.backgroundBRHSV = json.loads(self.data.config.get('Background Settings', 'backgroundBRHSV'))
+        self.data.backgroundTLPOS = json.loads(self.data.config.get('Background Settings', 'backgroundTLPOS'))
+        self.data.backgroundTRPOS = json.loads(self.data.config.get('Background Settings', 'backgroundTRPOS'))
+        self.data.backgroundBLPOS = json.loads(self.data.config.get('Background Settings', 'backgroundBLPOS'))
+        self.data.backgroundBRPOS = json.loads(self.data.config.get('Background Settings', 'backgroundBRPOS'))
+
+
+        #Fire off a clock to check for new images every 2 seconds - this should only run once per app start!
+        if self.data.backgroundClock is None:
+            self.data.backgroundClock=Clock.schedule_interval(self.timer, 2)
+
+    def findHSVcenter(self, img, hsv, hsvLow, hsvHi, bbtl, bbbr, clean=3, minarea=1000, maxarea=6000, tag="A"):
+        if isinstance(hsvLow, list):
+            #cv2 can't handle lists... make 'em into tuples
+            hsvLow = tuple(hsvLow)
+            hsvHi = tuple(hsvHi)
+            
+        #Mask to find the blobs
+        if hsvLow[0] > hsvHi[0]:
+            #It's wrapped [red]
+            bottom = (0, hsvLow[1], hsvLow[2])
+            maska=cv2.inRange(hsv, bottom,hsvHi)
+
+            top = (180, hsvHi[1], hsvHi[2])
+            maskb=cv2.inRange(hsv, hsvLow, top)
+            mask=cv2.bitwise_or(maska, maskb)
+        else:
+            mask=cv2.inRange(hsv, hsvLow, hsvHi)
+
+        #erode-dilate to clean up noise
+        mask = cv2.erode(mask, None, iterations=clean)
+        mask = cv2.dilate(mask, None, iterations=clean)
+
+        #find contours
+        cnts = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)[-2]
+        center = None
+        
+        #If we found some, lets check their size and location to pick the best ones
+        if len(cnts) > 0:
+            cnts = sorted(cnts, key=cv2.contourArea, reverse=True)  #Sort so we find biggest first.
+            for c in cnts:
+                if cv2.contourArea(c) >= minarea and cv2.contourArea(c)<=maxarea:                    #Discriminate based on size
+                    ((x, y), radius) = cv2.minEnclosingCircle(c)
+                    M = cv2.moments(c)
+                    center = (int(M["m10"] / M["m00"]), int(M["m01"] / M["m00"]))   #ToDo - why not use the XY above?
+                    if center[0] >= bbtl[0] and center[0] <= bbbr[0]  and center[1] >= bbtl[1] and center[1] <= bbbr[1]:
+                        #Mark the image
+                        cv2.circle(img, (int(x), int(y)), int(radius), (0, 255, 255), 5)
+                        cv2.circle(img, center, 5, (0, 0, 255), -1)
+                        return center
+        return center
+        
+    def openBackground(self):
+        '''
+        Open The Pop-up To Load A File
+        Creates a new pop-up which can be used to open a file.
+        '''
+        self.backgroundFile = self.data.config.get('Background Settings', 'backgroundFile')
+
+        #starting path is either where the last opened file was or the users home directory
+        if not os.path.isdir(self.backgroundFile):
+            startingPath = os.path.dirname(self.backgroundFile)
+        else:
+            startingPath = self.backgroundFile #Don't go up a dir if the "backgroundFile" is a directory!
+
+        print "SP:["+startingPath+"]"
+
+        if startingPath is "": 
+            startingPath = os.path.expanduser('~')
+                
+        #We want to filter to show only files that ground control can open
+        validFileTypes = graphicsExtensions
+        validFileTypes = ['*{0}'.format(fileType) for fileType in validFileTypes] #add a '*' to each one to match the format the widget expects
+        
+        content = FileBrowser(select_string='Select', 
+                    favorites=[(startingPath, 'Last Location')], 
+                    path = startingPath, 
+                    filters = validFileTypes, dirselect=False)
+                    
+        content.bind(on_success=self.load,
+                         on_canceled=self.dismiss_popup,
+                         on_submit=self.load)
+                    
+        self._popup = Popup(title="Select a file, or no file picks ""Latest File"" in this directory...", content=content,
+                            size_hint=(0.9, 0.9))
+        self._popup.open()
+        
+    def reloadBackground(self):
+        print "Reload: ["+self.backgroundFile+"]" #ToD: This aways shows up empty?
+
+        self.processBackground()
+        self.close()
+    
+    def timer(self, *args):
+        if self.doesNewFileExist():
+            self.processBackground()
+ 
+    def doesNewFileExist(self, *args):
+        print "Tick: ["+self.backgroundFile+"]"
+        if self.backgroundFile=="":
+            return False
+        
+        file=self.backgroundFile
+
+        #If file is a directory, then "load the latest from that directory"
+        if not os.path.isdir(file):
+            return False #I'm not going to automatically reload the same file
+        else:
+            files = os.listdir(file)
+            filelst =[]
+            for afile in files:
+                if afile.lower().endswith(graphicsExtensions):
+                    filelst.append(os.path.join(file,afile))
+            filelst.sort(key=os.path.getmtime, reverse=True)
+
+            if len(filelst) == 0:
+                file=None
+                return
+
+            file = filelst[0]
+            return file <> self.backgroundLastFile
+
+    def processBackground(self):
+        if self.backgroundFile=="":
+            print "NoBackgroundfile"
+            self.data.backgroundImage = None
+            self.data.gcodeRedraw=True
+        else:
+            print "ProcessBackground: ["+self.backgroundFile+"]"
+            file=self.backgroundFile
+            
+            #If file is a directory, then "load the latest from that directory"
+            if os.path.isdir(file):
+                files = os.listdir(file)
+                filelst =[]
+                for afile in files:
+                    if afile.lower().endswith(graphicsExtensions):
+                        filelst.append(os.path.join(file,afile))
+                
+                if len(filelst) == 0:
+                    file=None
+                    return
+                    
+                filelst.sort(key=os.path.getmtime, reverse=True)
+                file = filelst[0]
+
+                #Save the file we're processing...
+                self.backgroundLastFile = file
+                
+            img = cv2.imread(file)
+            self.data.originalimage=img.copy()
+            hsv = hsv = cv2.cvtColor(img, cv2.COLOR_BGR2HSV)    #HSV colorspace is easier to do "Color" than RGB
+            xmax=img.shape[1]
+            ymax=img.shape[0]
+            xmid = xmax/2
+            ymid = ymax/2;
+
+            #Find the centers of the markers:
+            centers = []
+            
+            if not isinstance(self.backgroundTLHSV,list) and not isinstance(self.backgroundTLHSV, tuple):
+                #Not a valid tuple or list, consider it a flag to go to manual mode immediately
+                centers.append(None)
+            else:
+                centers.append(self.findHSVcenter(img, hsv, self.backgroundTLHSV[0], self.backgroundTLHSV[1], (0,0), (xmid,ymid), tag="A"))
+                centers.append(self.findHSVcenter(img, hsv, self.backgroundTRHSV[0], self.backgroundTRHSV[1], (xmid,0),(xmax, ymid), tag="B"))
+                centers.append(self.findHSVcenter(img, hsv, self.backgroundBLHSV[0], self.backgroundBLHSV[1], (0,ymid), (xmid, ymax), tag="C"))
+                centers.append(self.findHSVcenter(img, hsv, self.backgroundBRHSV[0], self.backgroundBRHSV[1], (xmid,ymid), (xmax, ymax), tag="D"))
+            
+            self.data.backgroundImage = img
+            if None in centers:
+                self.realignBackground()
+            else:
+                #We have all points; just go on to warp_image
+                self.centers=centers
+                self.warp_image()
+                
+    def realignBackground(self):
+        self.data.backgroundImage=self.data.originalimage.copy() #Reload original image
+        content = BackgroundPickDlg(self.data)
+        content.setUpData(self.data)
+        content.close = self.close_PickDlg
+        self._popup = Popup(title="Background PointPicker", content=content, size_hint = (0.9,0.9))
+        self._popup.open()
+
+    def close_PickDlg(self, instance):
+        self.centers=instance.centers   #Grab the data
+        self.dismiss_popup()            #Close pointpicker dialog
+        self.warp_image()               #Process with the user-picked centers
+        self.close()                    #Close background menu dialog
+        
+    def warp_image(self):
+        #Load into locals for shorthand... this skew correction is similar to gcodeCanvas.py
+        centers=self.centers
+        if len(centers)==4:
+            TL=self.data.backgroundTLPOS
+            TR=self.data.backgroundTRPOS
+            BL=self.data.backgroundBLPOS
+            BR=self.data.backgroundBRPOS
+
+            #Handle skew in output coordinates
+            leftmost = min(TL[0],BL[0])
+            rightmost=max(TR[0],BR[0])
+            topmost=max(TL[1],TR[1])
+            botmost=min(BL[1],BR[1])
+            h = topmost-botmost
+            w = rightmost-leftmost
+
+            #Construct transformation matrices
+            pts1 = np.float32([centers[0],centers[1],centers[2],centers[3]])
+            pts2 = np.float32(
+                [[TL[0]-leftmost,TL[1]-botmost],[TR[0]-leftmost, TR[1]-botmost],
+                 [BL[0]-leftmost,BL[1]-botmost],[BR[0]-leftmost,BR[1]-botmost]]) 
+            
+            M = cv2.getPerspectiveTransform(pts1,pts2)
+            
+            self.data.backgroundImage = cv2.warpPerspective(self.data.backgroundImage,M,(w,h))
+                
+        #Trigger a redraw
+        self.data.gcodeRedraw=True
+        
+    def clear_background(self):
+        '''
+        Clear background
+        '''
+        print "Clear"
+        self.backgroundFile=""
+        self.processBackground()
+        self.close()
+        
+    def load(self, instance):
+        '''
+        Load A Background Image File from the file dialog
+        Takes in a file path (from the pop-up filepicker) (or directory, if no file picked) and processes it.
+        '''
+        if len(instance.selection)==1:
+            filename = instance.selection[0]
+        else:
+            filename = instance.path    #User pressed Submit without picking a file, indicating "newest in this dir"
+
+        #Save the file in the config...
+        self.backgroundFile = filename
+        self.data.config.set('Background Settings', 'openFile', str(self.backgroundFile))
+        self.data.config.write()
+        print "Open: ["+self.backgroundFile+"]"
+        
+        #close the open file popup
+        self.dismiss_popup()
+        
+        #process it
+        self.processBackground()
+        
+        #Close the menu, going back to the main page.
+        self.close()
+    
+    def openBackgroundSettings(self):
+        '''
+        Open the background settings page
+        '''
+        content = BackgroundSettingsDlg(self)
+        content.close = self.closeBackgroundSettings
+        self._popup = Popup(title="Background Settings", content=content, size_hint = (0.6,0.5))
+        self._popup.open()
+        
+    def closeBackgroundSettings(self, instance):
+        #Convert string data back into lists for use (should be a list of tuples, but I fixed it so it can be a list of lists)...
+        self.backgroundTLHSV =json.loads(instance.backgroundTLHSV)
+        self.backgroundTRHSV =json.loads(instance.backgroundTRHSV)
+        self.backgroundBLHSV =json.loads(instance.backgroundBLHSV)
+        self.backgroundBRHSV =json.loads(instance.backgroundBRHSV)
+        self.data.backgroundTLPOS =json.loads(instance.backgroundTLPOS)
+        self.data.backgroundTRPOS =json.loads(instance.backgroundTRPOS)
+        self.data.backgroundBLPOS =json.loads(instance.backgroundBLPOS)
+        self.data.backgroundBRPOS =json.loads(instance.backgroundBRPOS)
+
+        #Write the data to the config file (just use the json data)
+        self.data.config.set('Background Settings', 'backgroundTLHSV', instance.backgroundTLHSV)
+        self.data.config.set('Background Settings', 'backgroundTRHSV', instance.backgroundTRHSV)
+        self.data.config.set('Background Settings', 'backgroundBLHSV', instance.backgroundBLHSV)
+        self.data.config.set('Background Settings', 'backgroundBRHSV', instance.backgroundBRHSV)
+        self.data.config.set('Background Settings', 'backgroundTLPOS', instance.backgroundTLPOS)
+        self.data.config.set('Background Settings', 'backgroundTRPOS', instance.backgroundTRPOS)
+        self.data.config.set('Background Settings', 'backgroundBLPOS', instance.backgroundBLPOS)
+        self.data.config.set('Background Settings', 'backgroundBRPOS', instance.backgroundBRPOS)        
+        self.data.config.write()
+        self._popup.dismiss()   #Close the settings popup
+        
+    
+    def dismiss_popup(self, *args):
+        '''
+        Close The File Picker (cancel was pressed instead of OK).
+        '''
+        self._popup.dismiss()
+        pass #And take no other action...

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -15,6 +15,8 @@ from UIElements.viewMenu                     import ViewMenu
 from kivy.graphics.transformation            import Matrix
 from kivy.core.window                        import Window
 from UIElements.modernMenu                   import ModernMenu
+from kivy.graphics.texture                   import Texture
+from kivy.graphics							 import Rectangle
 
 import re
 import math
@@ -48,13 +50,15 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         if self.data.config.getboolean('Ground Control Settings', 'centerCanvasOnResize'):
             Window.bind(on_resize = self.centerCanvas)
 
-        self.data.bind(gcode = self.updateGcode)
-        self.data.bind(gcodeShift = self.reloadGcode)
-        self.data.bind(gcodeFile = self.centerCanvasAndReloadGcode)
+        self.data.bind(gcode = self.updateGcode)                    #Parses self.data.gcode and draws if you change self.data.gcode
+        self.data.bind(gcodeRedraw = self.pupdateGcode)             #Easy way for other pieces to call for a redraw with no changes
+        self.data.bind(gcodeShift = self.pupdateGcode)              #No need to reload if the origin is changed, just clear and redraw
+        self.data.bind(gcodeFile = self.centerCanvasAndReloadGcode) #If filename changed, center canvas and reload file
         
         global_variables._keyboard = Window.request_keyboard(self._keyboard_closed, self)
         global_variables._keyboard.bind(on_key_down=self._on_keyboard_down)
         
+        #Load it up from the saved data
         self.centerCanvasAndReloadGcode()
     
     def addPoint(self, x, y):
@@ -116,49 +120,54 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
 
         try:
             filterfile = open(filename, 'r')
-            rawfilters = filterfile.read()
-
-            filtersparsed = re.sub(r'\(([^)]*)\)','\n',rawfilters) #replace mach3 style gcode comments with newline
-            filtersparsed = re.sub(r';([^\n]*)\n','\n',filtersparsed) #replace standard ; initiated gcode comments with newline
-            filtersparsed = re.sub(r'\n\n','\n',filtersparsed) #removes blank lines
-            filtersparsed = re.sub(r'([0-9])([GXYZIJFTM]) *', '\\1 \\2',filtersparsed) #put spaces between gcodes
-            filtersparsed = re.sub(r'  +',' ',filtersparsed) #condense space runs
-
-            if self.data.config.getint('Advanced Settings','truncate'):
-                digits = self.data.config.get('Advanced Settings','digits')
-                filtersparsed = re.sub(r'([+-]?\d*\.\d{1,'+digits+'})(\d*)',r'\g<1>',filtersparsed) #truncates all long floats to 4 decimal places, leaves shorter floats
-
-            filtersparsed = re.split('\n', filtersparsed) #splits the gcode into elements to be added to the list
-            filtersparsed = [x + ' ' for x in filtersparsed] #adds a space to the end of each line
-            filtersparsed = [x.lstrip() for x in filtersparsed]
-            filtersparsed = [x.replace('X ','X') for x in filtersparsed]
-            filtersparsed = [x.replace('Y ','Y') for x in filtersparsed]
-            filtersparsed = [x.replace('Z ','Z') for x in filtersparsed]
-            filtersparsed = [x.replace('I ','I') for x in filtersparsed]
-            filtersparsed = [x.replace('J ','J') for x in filtersparsed]
-            filtersparsed = [x.replace('F ','F') for x in filtersparsed]
-            
-            self.data.gcode = "[]"
-            self.data.gcode = filtersparsed
+            rawfilters = filterfile.read()      #Read the whole thing
+            self.data.gcodeOriginal = rawfilters
             
             filterfile.close() #closes the filter save file
-
-            #Find gcode indicies of z moves
-            self.data.zMoves = [0]
-            zList = []
-            for index, line in enumerate(self.data.gcode):
-                z = re.search("Z(?=.)([+-]?([0-9]*)(\.([0-9]+))?)",line)
-                if z:
-                    zList.append(z)
-                    if len(zList) > 1:
-                        if not self.isClose(float(zList[-1].groups()[0]),float(zList[-2].groups()[0])):
-                            self.data.zMoves.append(index-1)
-                    else:
-                        self.data.zMoves.append(index)
         except:
             self.data.message_queue.put("Message: Cannot reopen gcode file. It may have been moved or deleted. To locate it or open a different file use Actions > Open G-code")
             self.data.gcodeFile = ""
-    
+        self.processFile()
+        
+    def processFile(self):
+        rawfilters = self.data.gcodeOriginal #Reload Raw...
+        
+        filtersparsed = re.sub(r'\(([^)]*)\)','',rawfilters) #replace mach3 style gcode comments with nothing (the newline is still there)
+        filtersparsed = re.sub(r';([^\n]*)\n','\n',filtersparsed) #replace standard ; initiated gcode comments with newline (the newline got matched)
+        filtersparsed = re.sub(r'([0-9])([GXYZIJFTM]) *', '\\1 \\2',filtersparsed) #put spaces between gcodes
+        filtersparsed = re.sub(r'  +',' ',filtersparsed) #condense space runs
+
+        if self.data.config.getint('Advanced Settings','truncate'):
+            digits = self.data.config.get('Advanced Settings','digits')
+            filtersparsed = re.sub(r'([+-]?\d*\.\d{1,'+digits+'})(\d*)',r'\g<1>',filtersparsed) #truncates all long floats to 4 decimal places, leaves shorter floats
+
+        filtersparsed = re.split('\n', filtersparsed) #splits the gcode into elements to be added to the list
+        filtersparsed = [x + ' ' for x in filtersparsed] #adds a space to the end of each line
+        filtersparsed = [x.lstrip() for x in filtersparsed]
+        filtersparsed = [x.replace('X ','X') for x in filtersparsed]
+        filtersparsed = [x.replace('Y ','Y') for x in filtersparsed]
+        filtersparsed = [x.replace('Z ','Z') for x in filtersparsed]
+        filtersparsed = [x.replace('I ','I') for x in filtersparsed]
+        filtersparsed = [x.replace('J ','J') for x in filtersparsed]
+        filtersparsed = [x.replace('F ','F') for x in filtersparsed]
+        
+        self.data.gcode = "[]"
+        self.data.gcode = filtersparsed
+        
+
+        #Find gcode indicies of z moves
+        self.data.zMoves = [0]
+        zList = []
+        for index, line in enumerate(self.data.gcode):
+            z = re.search("Z(?=.)([+-]?([0-9]*)(\.([0-9]+))?)",line)
+            if z:
+                zList.append(z)
+                if len(zList) > 1:
+                    if not self.isClose(float(zList[-1].groups()[0]),float(zList[-2].groups()[0])):
+                        self.data.zMoves.append(index-1)
+                else:
+                    self.data.zMoves.append(index)
+        
     def centerCanvas(self, *args):
         '''
         
@@ -196,6 +205,29 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
  
         with self.scatterObject.canvas:
             Color(.47, .47, .47)
+            img = self.data.backgroundImage
+            
+            if img is not None: #If img is None, then no background.  Skip this mess.
+                print "DrawBkgrnd"
+                w=int(img.shape[0])
+                h=int(img.shape[1])
+                #For a canvas, it goes in as a texture on a rectangle, so make the texture
+                texture = Texture.create(size=(h,w))
+
+                buf = img.tobytes() # then, convert the array to a ubyte string
+                texture.blit_buffer(buf, colorfmt='bgr', bufferfmt='ubyte') # and blit the buffer -- note that OpenCV format is BGR
+
+                #The coordinates are for the bottom-left corner.  This code duplicates the backgroundMenu:processBackground logic
+                TL=self.data.backgroundTLPOS
+                TR=self.data.backgroundTRPOS
+                BL=self.data.backgroundBLPOS
+                BR=self.data.backgroundBRPOS
+                
+                leftmost = min(TL[0],BL[0])
+                rightmost=max(TR[0],BR[0])
+                topmost=max(TL[1],TR[1])
+                botmost=min(BL[1],BR[1])
+                Rectangle(texture=texture, pos=(leftmost,botmost), size=(rightmost-leftmost, topmost-botmost))
 
             #create the bounding box
             height = float(self.data.config.get('Maslow Settings', 'bedHeight'))
@@ -208,6 +240,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             #create the axis lines
             Line(points = (-width/2,0,width/2,0), dash_offset = 5, group='workspace')
             Line(points = (0, -height/2,0,height/2), dash_offset = 5, group='workspace')
+			
     
     def drawLine(self,gCodeLine,command):
         '''
@@ -516,7 +549,12 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         #Repeat until end of file
         if self.lineNumber < min(len(self.data.gcode),60000):
             Clock.schedule_once(self.callBackMechanism)
-    
+
+    def pupdateGcode(self, *args):
+        #Force a re-process of the g-code, because as-we-draw-it, the draw shifts the coordinates around
+        #So if you just "update", the gcode will shift around based on where your origin is
+        self.processFile()
+            
     def updateGcode(self, *args):
         '''
         
@@ -526,6 +564,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         '''
         
         #reset variables 
+        self.data.gcodeRedraw=False #Reset the redraw flag
         self.xPosition = self.data.gcodeShift[0]*self.canvasScaleFactor
         self.yPosition = self.data.gcodeShift[1]*self.canvasScaleFactor
         self.zPosition = 0

--- a/UIElements/screenControls.py
+++ b/UIElements/screenControls.py
@@ -3,7 +3,23 @@ from kivy.uix.popup                            import   Popup
 from UIElements.otherFeatures                  import   OtherFeatures
 from DataStructures.makesmithInitFuncs         import   MakesmithInitFuncs
 from UIElements.buttonTemplate                 import   ButtonTemplate
+from UIElements.backgroundMenu                 import   BackgroundMenu
+import numpy as np
 
+def adjust_background(self, increment):
+    '''
+    Adjust the background and refresh the UIElements
+    '''
+    img = self.data.backgroundImage
+    if img is not None:
+        img = img.astype('int16')       #Expand the range
+        img += increment                #Do the math
+        np.clip(img, 0, 255, out=img)   #Clip the image (no wrapping!)
+        img = img.astype('uint8')       #Convert it back
+        self.data.backgroundImage = img #Reset it
+        
+        #Trigger a reload
+    self.data.gcodeRedraw=True
 
 class ScreenControls(FloatLayout, MakesmithInitFuncs):
     
@@ -14,11 +30,12 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         Called on creation to set up links to button background textures
         
         '''
-        self.actionsBtn.btnBackground            = self.data.iconPath + 'Generic.png'
-        self.actionsBtn.textColor                = self.data.fontColor
-        self.settingsBtn.btnBackground           = self.data.iconPath + 'Generic.png'
-        self.settingsBtn.textColor               = self.data.fontColor
-    
+        #For some reason, my +/- buttons didn't work with the old way, so I'll set everything.
+        for widget in self.walk():
+            if "ButtonTemplate"in str(type(widget)):
+                widget.btnBackground            = self.data.iconPath + 'Generic.png'
+                widget.textColor                = self.data.fontColor
+         
     def show_actions(self):
         '''
         
@@ -29,13 +46,35 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         '''
         content = OtherFeatures()
         content.setUpData(self.data)
-        content.close = self.close_actions
+        content.close = self.close_popup
         self._popup = Popup(title="Actions", content=content,
                             size_hint=(0.9, 0.9))
         self._popup.open()
     
-    def close_actions(self):
+    def close_popup(self):
         '''
         Close pop-up
         '''
         self._popup.dismiss()
+		
+    def open_background(self):
+        '''
+        Open A Pop-up To Manage the Canvas Background
+        '''
+        content = BackgroundMenu(self.data)
+        content.setUpData(self.data)
+        content.close = self.close_popup
+        self._popup = Popup(title="Background Picture", content=content, size_hint = (0.5,0.5))
+        self._popup.open()
+        
+    def brighten_background(self):
+        '''
+        Brighten the background
+        '''
+        adjust_background(self,25)
+        
+    def darken_background(self):
+        '''
+        Darken the background
+        '''
+        adjust_background(self,-20)

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -141,9 +141,11 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
             if line>len(self.data.gcode):
                 line = len(self.data.gcode)-447
 
-            for lineNum, gcodeLine in enumerate(self.data.gcode):
+            orgcode = re.split('\n', self.data.gcodeOriginal)
+            
+            for lineNum, gcodeLine in enumerate(orgcode):
                 if lineNum>=line and lineNum<line+447:
-                    popupText = popupText + str(lineNum+1) + ': ' + gcodeLine + "\n"
+                    popupText = popupText + str(lineNum+1) + ': ' + gcodeLine + "  {"+self.data.gcode[lineNum]+ "}\n"
                 elif lineNum>=line+447:
                     popupText = popupText + "...\n...\n...\n"
                     break

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -27,6 +27,7 @@
 <ScreenControls>:
     actionsBtn:actionsBtn
     settingsBtn:settingsBtn
+	backgroundBtn:backgroundBtn
 
     BoxLayout:
         orientation: 'horizontal'
@@ -42,6 +43,23 @@
             text: "Settings"
             funcToCallOnRelease: app.open_settings
             id: settingsBtn
+        ButtonTemplate:
+            text: "Background"
+            funcToCallOnRelease: root.open_background
+            id: backgroundBtn
+		ButtonTemplate:
+			size_hint: None, 1
+			width: dp(60)
+			name: backgroundLightBtn
+			text: "+"
+			funcToCallOnPress: root.brighten_background
+			id: backgroundLightBtn
+		ButtonTemplate:
+			size_hint: None,1
+			width: dp(60)
+			text: "-"
+			funcToCallOnPress: root.darken_background
+			id: backgroundDarkBtn
 
 <GcodeCanvas>:
     scatterObject:scatterObject
@@ -371,13 +389,14 @@
                 text: 'Test Motors/Encoders'
                 on_press: root.testMotors()
             Button:
-                text: 'Calibrate'
+                text: 'Calibrate Machine Dimensions'
                 on_release: root.measureMachine()
             Button:
-                text: 'Set Chain Length - Automatic'
+                text: 'Calibrate Chain Length - Automatic'
                 on_release: root.calibrateChainLengths()
             Button:
-                text: ' '
+                text: 'Calibrate Motors\n-----Obsolete-----'
+                on_release: root.calibrateMotors()
                 disabled: True
             Button:
                 text: 'About'
@@ -386,7 +405,7 @@
             Spinner:
                 id: advancedOptions
                 text: "Advanced"
-                values: ["Set Chain Length - Manual", "Wipe EEPROM", "Simulation", "Load Calibration Benchmark Test"]
+                values: ["Calibrate Chain Length - Manual", "Wipe EEPROM", "Simulation", "Load Calibration Benchmark Test"]
                 on_text: root.advancedOptionsFunctions(advancedOptions.text)
 
 <OtherFeatures>:
@@ -666,33 +685,6 @@
                 # color: [1,0,0,1]
                 on_release: root.stopZMove()
 
-#calibration widgets
-
-<CalibrationTemplate>:
-    GridLayout:
-        cols: 2
-        width: root.width
-        height: root.height
-        GridLayout:
-            cols: 1
-            size_hint_x: leftCol
-            Label:
-                text: "Text about what to do in this step"
-                size_hint_x: leftCol
-            GridLayout:
-                cols: 2
-                Image:
-                    source: "./Documentation/Calibrate Machine Dimensions/Set Z Height.jpg"
-        GridLayout:
-            cols: 1
-            size_hint_x: rightCol
-            Label:
-            Button:
-                text: "Thing one"
-            Button:
-                text: 'Thing two'
-            Label:
-  
 <TriangularCalibration>:
     cutBtnT:cutBtnT
     horzMeasureT1:horzMeasureT1
@@ -1274,8 +1266,6 @@
                     on_release: root.done()
                 Label:
 
-#simulation widgets
-
 <SimulationCanvas>:
     motorSpacingError:motorSpacingError
     motorVerticalError:motorVerticalError
@@ -1450,6 +1440,124 @@
             Button:
                 text: "Recompute"
                 on_release: root.recompute()
+
+<BackgroundMenu>:
+    cols:1
+    size: root.size
+    pos: root.pos
+    Button:
+        text: 'Open Background'
+        on_release: root.openBackground()
+	Button:
+		text: 'Re-pick Alignment'
+		on_release: root.realignBackground()
+		disabled: app.data.originalimage is None
+    Button:
+        text: 'Update Background'
+        on_release: root.reloadBackground()
+    Button:
+        text: 'Remove Background'
+        on_release: root.clear_background()
+    Button:
+        text: 'Settings...'
+        on_release: root.openBackgroundSettings()
+    Button:
+        text: 'Close'
+        on_press: app.frontpage.gcodecanvas.centerCanvas() #Force canvas redraw
+        on_release: root.close()
+					
+<BackgroundPickDlg>
+	cols:1
+	size: root.size
+	pos: root.pos
+	#Top Bar
+	GridLayout:
+		cols: 3
+		size_hint_y: None
+		Label:
+			text: root.instructionText
+			text_size: self.width, self.height
+			font_size: sp(self.height)/sp(3)
+			halign: 'left'
+			valign: 'center'
+		Button:
+			size_hint_x: None
+			text: 'Clear'
+			on_press: app.frontpage.gcodecanvas.centerCanvas() #Force canvas redraw
+			on_release: root.clear()
+		Button:
+			size_hint_x: None
+			text: 'Close'
+			on_press: app.frontpage.gcodecanvas.centerCanvas() #Force canvas redraw
+			on_release: root.closeit()
+	#Underneath
+	Widget:
+		text: 'Foo'	#For some reason self.Drawing doesn't work, so I search for this tag.  ToDo: Fix this.
+		id: Drawing	#I suppose I should use a Scatter Object, but I'm not sure how.
+		#on_touch_down: root.touched		#For some reason, these don't get called.  But if there's no function behind them, it explodes.
+		#on_touch_move: root.touchmove		#So I do it with a Bind...
+		#on_touch_up: root.untouched
+		canvas:
+			Color:
+				rgba: 1, 1, 1, 1
+			Rectangle:
+				pos: self.pos
+				size: self.size
+					
+<BackgroundSettingsDlg>:
+	tlpos:tlpos	#Make these controls accessible to the code
+	trpos:trpos
+	blpos:blpos
+	brpos:brpos
+	tlhsv:tlhsv
+	trhsv:trhsv
+	blhsv:blhsv
+	brhsv:brhsv
+	cols: 1
+	GridLayout:
+		cols:3
+		Label:
+			text: "Location"
+		Label:
+			text: "Dist from Center (mm)"
+		Label:
+			text: "HSV limits (for auto-align)"
+		Label:
+			text: "Top-Left:"
+		TextInput:
+			id: tlpos
+			text: root.backgroundTLPOS
+		TextInput:
+			id: tlhsv
+			text: root.backgroundTLHSV
+		Label:
+			text: "Top-Right:"
+		TextInput:
+			id: trpos
+			text: root.backgroundTRPOS
+		TextInput:
+			id: trhsv
+			text: root.backgroundTRHSV
+		Label:
+			text: "Bottom-Left:"
+		TextInput:
+			id: blpos
+			text: root.backgroundBLPOS
+		TextInput:
+			id: blhsv
+			text: root.backgroundBLHSV
+		Label:
+			text: "Bottom-Right:"
+		TextInput:
+			id: brpos
+			text: root.backgroundBRPOS
+		TextInput:
+			id: brhsv
+			text: root.backgroundBRHSV
+	Button:
+		size_hint_y:.1
+		text: 'Close'
+		on_press: root.closeit()
 
 <TestPoint>
 

--- a/main.py
+++ b/main.py
@@ -52,7 +52,7 @@ class GroundControlApp(App):
 
     def get_application_config(self):
         return super(GroundControlApp, self).get_application_config(
-            '~/%(appname)s.ini')
+            '~/%(appname)s.ini')    
     
     def build(self):
         
@@ -103,6 +103,7 @@ class GroundControlApp(App):
         self.data.gcodeShift = [offsetX,offsetY]
         self.data.config  = self.config
         
+        
         '''
         Initializations
         '''
@@ -135,8 +136,9 @@ class GroundControlApp(App):
         config.setdefaults('Maslow Settings', maslowSettings.getDefaultValueSection('Maslow Settings'))
         config.setdefaults('Advanced Settings', maslowSettings.getDefaultValueSection('Advanced Settings'))
         config.setdefaults('Ground Control Settings', maslowSettings.getDefaultValueSection('Ground Control Settings'))
+        config.setdefaults('Background Settings', maslowSettings.getDefaultValueSection('Background Settings'))
         config.remove_callback(self.computeSettings)
-        
+                                            
     def build_settings(self, settings):
         """
         Add custom section to the default configuration object.
@@ -144,6 +146,7 @@ class GroundControlApp(App):
         settings.add_json_panel('Maslow Settings', self.config, data=maslowSettings.getJSONSettingSection('Maslow Settings'))
         settings.add_json_panel('Advanced Settings', self.config, data=maslowSettings.getJSONSettingSection('Advanced Settings'))
         settings.add_json_panel('Ground Control Settings', self.config, data=maslowSettings.getJSONSettingSection("Ground Control Settings"))
+        settings.add_json_panel('Background Settings', self.config, data=maslowSettings.getJSONSettingSection("Background Settings"))
         self.config.add_callback(self.configSettingChange)
 
     def computeSettings(self, section, key, value):
@@ -326,6 +329,10 @@ class GroundControlApp(App):
                 pass #displaying all the 'ok' messages clutters up the display
             else:
                 self.writeToTextConsole(message)
+
+        #See if we got a new file in the Background Image Directory -- ToDo: Every time?
+        #if self.frontpage.BackgroundMenu.DoesNewFileExist():
+        #   self.frontpage.BackgroundMenu.processBackground()
 
     def ondismiss_popup(self, event):
         if global_variables._keyboard:


### PR DESCRIPTION
Replaces PR #613 and PR #636, and doesn't pollute self.data as much as the old one.
You must use opencv; install with `python -m pip install opencv-python` as the scatterobject won't stretch things, and the texture_wrap won't stretch things caddywompus.

You might be able to do it with a kivy Transformation matrices, but I don't know how you'd calculate them (opencv can do it with 4 points from source to 4 points on dest).  -- The code that does this is `backgroundmenu.py:229` (warp_image)

**There is a bug:** When you reload_background, it blanks it instead - `backgroundMenu.py:126`
I dealt with this before by putting all the variables into the self.data space, but that seems polluting...
Does anyone know why `self.backgroundFile` shows up empty here when it's still detected by "Tick"?

**And another bug:** The backgroundFile is /not/ being saved/loaded properly.  I patterned it after gcodeFile, but evidently I suck at strings?!

Anyone know why I can't get these 2 to cooperate?