### PR TITLE
Remove Unnecessary Calls to PushSettings and Config.Write()

### DIFF
--- a/CalibrationWidgets/adjustZCalibrationDepth.py
+++ b/CalibrationWidgets/adjustZCalibrationDepth.py
@@ -35,8 +35,6 @@ class AdjustZCalibrationDepth(GridLayout):
 
         '''
         self.data.config.set('Maslow Settings', 'zAxis', int(self.zAxisActiveSwitch.active))
-        self.data.config.write()
-        self.data.pushSettings()
         
         #enable and disable the button to open the z-axis popup
         if self.zAxisActiveSwitch.active == True:

--- a/CalibrationWidgets/chooseChainOverSprocketDirection.py
+++ b/CalibrationWidgets/chooseChainOverSprocketDirection.py
@@ -26,7 +26,6 @@ class ChooseChainOverSprocketDirection(GridLayout):
         
         '''
         App.get_running_app().data.config.set('Advanced Settings', 'chainOverSprocket', 'Top')
-        App.get_running_app().data.config.write()
         self.on_Exit()
     
     def setChainToBottom(self):
@@ -36,7 +35,6 @@ class ChooseChainOverSprocketDirection(GridLayout):
         
         '''
         App.get_running_app().data.config.set('Advanced Settings', 'chainOverSprocket', 'Bottom')
-        App.get_running_app().data.config.write()
         self.on_Exit()
     
     def on_Exit(self):

--- a/CalibrationWidgets/chooseKinematicsType.py
+++ b/CalibrationWidgets/chooseKinematicsType.py
@@ -27,7 +27,6 @@ class ChooseKinematicsType(GridLayout):
         '''
         print "set quad"
         App.get_running_app().data.config.set('Advanced Settings', 'kinematicsType', 'Quadrilateral')
-        App.get_running_app().data.config.write()
         self.on_Exit()
     
     def setKinematicsTypeTri(self):
@@ -38,7 +37,6 @@ class ChooseKinematicsType(GridLayout):
         '''
         print "set tri"
         App.get_running_app().data.config.set('Advanced Settings', 'kinematicsType', 'Triangular')
-        App.get_running_app().data.config.write()
         self.on_Exit()
     
     def on_Exit(self):

--- a/CalibrationWidgets/distBetweenChainBrackets.py
+++ b/CalibrationWidgets/distBetweenChainBrackets.py
@@ -88,7 +88,6 @@ class DistBetweenChainBrackets(GridLayout):
         try:
             dist = float(self.enterMeasurement.text)
             self.data.config.set('Maslow Settings', 'sledWidth', str(dist))
-            self.data.config.write()
             self.readyToMoveOn()
         except:
             self.data.message_queue.put("Message: Couldn't convert that to a number...")

--- a/CalibrationWidgets/intro.py
+++ b/CalibrationWidgets/intro.py
@@ -27,6 +27,4 @@ class Intro(GridLayout):
         '''
         print "intro on exit"
         App.get_running_app().data.config.set('Advanced Settings', 'chainOverSprocket', 'Top')
-        App.get_running_app().data.config.write()
-        App.get_running_app().data.pushSettings()
         self.readyToMoveOn()

--- a/CalibrationWidgets/measureDistBetweenMotors.py
+++ b/CalibrationWidgets/measureDistBetweenMotors.py
@@ -98,7 +98,6 @@ class MeasureDistBetweenMotors(GridLayout):
 
         print "Read motor spacing: " + str(dist)
         self.data.config.set('Maslow Settings', 'motorSpacingX', str(dist))
-        self.data.config.write()
         
         #put some slack in the chain
         self.data.gcode_queue.put("G91 ")

--- a/CalibrationWidgets/measureMachinePopup.py
+++ b/CalibrationWidgets/measureMachinePopup.py
@@ -129,7 +129,6 @@ class MeasureMachinePopup(GridLayout):
 
         if self.carousel.index == 9:
             #Cut test shape triangular
-            self.data.pushSettings()
             self.stepText = "Step 10 of 10"
             self.goFwdBtn.disabled = False
 
@@ -139,7 +138,6 @@ class MeasureMachinePopup(GridLayout):
 
         if self.carousel.index == 10:
             #Cut test shape quadrilateral
-            self.data.pushSettings()
             self.goFwdBtn.disabled = False
             self.stepText = "Step 10 of 10"
 
@@ -199,7 +197,6 @@ class MeasureMachinePopup(GridLayout):
             dist *= -1
         print "vertical offset measured at: " + str(dist)
         self.data.config.set('Maslow Settings', 'motorOffsetY', str(dist))
-        self.data.config.write()
 
 
         #keep updating the values shown because sometimes it takes a while for the settings to write
@@ -276,7 +273,6 @@ class MeasureMachinePopup(GridLayout):
             return
 
         self.data.config.set('Maslow Settings', 'sledWidth', str(dist))
-        self.data.config.write()
 
         self.carousel.load_next()
 
@@ -309,7 +305,6 @@ class MeasureMachinePopup(GridLayout):
         print self.kinematicsType
 
         self.data.config.set('Advanced Settings', 'kinematicsType', self.kinematicsType)
-        self.data.config.write()
 
         if self.kinematicsType == 'Triangular':
             try:
@@ -320,7 +315,6 @@ class MeasureMachinePopup(GridLayout):
                 #Set up a good initial guess for the radius
                 print "Rotation radius set to 260"
                 self.data.config.set('Advanced Settings', 'rotationRadius', 260)
-                self.data.config.write()
             self.carousel.load_next()
         else:
 
@@ -388,9 +382,7 @@ class MeasureMachinePopup(GridLayout):
             newSledSpacing = float(self.data.config.get('Maslow Settings', 'sledWidth')) + amtToChange
             print "Now trying spacing: " + str(newSledSpacing)
             self.data.config.set('Maslow Settings', 'sledWidth', str(newSledSpacing))
-            self.data.config.write()
             self.cutBtn.disabled = False
-            self.data.pushSettings()
 
     def stopCut(self):
         self.data.quick_queue.put("!")

--- a/CalibrationWidgets/measureOutChains.py
+++ b/CalibrationWidgets/measureOutChains.py
@@ -28,7 +28,6 @@ class MeasureOutChains(GridLayout):
             self.data.gcode_queue.queue.clear()
     
     def next(self):
-        self.data.pushSettings() #push settings to machine so it centers properly
         self.data.gcode_queue.put("B15 ")
         self.on_Exit()
     

--- a/CalibrationWidgets/quadTestCut.py
+++ b/CalibrationWidgets/quadTestCut.py
@@ -88,9 +88,7 @@ class QuadTestCut(GridLayout):
             newSledSpacing = float(self.data.config.get('Maslow Settings', 'sledWidth')) + amtToChange
             print "Now trying spacing: " + str(newSledSpacing)
             self.data.config.set('Maslow Settings', 'sledWidth', str(newSledSpacing))
-            self.data.config.write()
             self.cutBtn.disabled = False
-            self.data.pushSettings()
     
     def stopCut(self):
         self.data.quick_queue.put("!")

--- a/CalibrationWidgets/rotationRadiusGuess.py
+++ b/CalibrationWidgets/rotationRadiusGuess.py
@@ -88,7 +88,6 @@ class RotationRadiusGuess(GridLayout):
         try:
             dist = float(self.enterMeasurement.text)
             self.data.config.set('Advanced Settings', 'rotationRadius', str(dist))
-            self.data.config.write()
             print "setting rotation radius to: " + str(dist)
             print self.data.config.get('Advanced Settings', 'rotationRadius')
             self.readyToMoveOn()

--- a/CalibrationWidgets/triangularCalibration.py
+++ b/CalibrationWidgets/triangularCalibration.py
@@ -24,7 +24,6 @@ class TriangularCalibration(GridLayout):
         
         '''
         self.data = App.get_running_app().data
-        self.data.pushSettings()                    #update machine settings so that the test cut is accurate
     
     def cutTestPaternTriangular(self):
 
@@ -357,8 +356,6 @@ class TriangularCalibration(GridLayout):
         self.data.config.set('Maslow Settings', 'motorOffsetY', str(motorYoffsetEst))
         self.data.config.set('Advanced Settings', 'rotationRadius', str(rotationRadiusEst))
         self.data.config.set('Advanced Settings', 'chainSagCorrection', str(chainSagCorrectionEst))
-        self.data.config.write()
-        self.data.pushSettings()
 
         # With new calibration parameters return sled to workspace center
 

--- a/CalibrationWidgets/vertDistToMotorsGuess.py
+++ b/CalibrationWidgets/vertDistToMotorsGuess.py
@@ -88,7 +88,6 @@ class VertDistToMotorsGuess(GridLayout):
         try:
             dist = float(self.enterMeasurement.text)
             self.data.config.set('Maslow Settings', 'motorOffsetY', str(dist))
-            self.data.config.write()
             self.readyToMoveOn()
         except:
             self.data.message_queue.put("Message: Couldn't convert that to a number...")

--- a/Connection/serialPort.py
+++ b/Connection/serialPort.py
@@ -47,7 +47,6 @@ class SerialPort(MakesmithInitFuncs):
         
         '''
         self.data.config.set('Makesmith Settings', 'COMport', str(self.data.comport))
-        self.data.config.write()
         
     '''
     

--- a/UIElements/connectMenu.py
+++ b/UIElements/connectMenu.py
@@ -20,7 +20,6 @@ class ConnectMenu(FloatLayout, MakesmithInitFuncs):
     def connect(self, *args):
         
         self.data.config.set('Maslow Settings', 'COMport', str(self.data.comport))
-        self.data.config.write()
         
         #close the parent popup
         self.parentWidget.close()

--- a/UIElements/frontPage.py
+++ b/UIElements/frontPage.py
@@ -361,7 +361,6 @@ class FrontPage(Screen, MakesmithInitFuncs):
         self.data.gcodeShift = [self.numericalPosX,self.numericalPosY]
         self.data.config.set('Advanced Settings', 'homeX', str(self.numericalPosX))
         self.data.config.set('Advanced Settings', 'homeY', str(self.numericalPosY))
-        self.data.config.write()
     
     def startRun(self):
         

--- a/UIElements/viewMenu.py
+++ b/UIElements/viewMenu.py
@@ -90,7 +90,6 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         #locate the file
         self.data.gcodeFile = filename
         self.data.config.set('Maslow Settings', 'openFile', str(self.data.gcodeFile))
-        self.data.config.write()
 
         #close the parent popup
         self.parentWidget.close()
@@ -113,7 +112,6 @@ class ViewMenu(GridLayout, MakesmithInitFuncs):
         #locate the file
         self.data.gcodeFile = ""
         self.data.config.set('Maslow Settings', 'openFile', str(self.data.gcodeFile))
-        self.data.config.write()
 
         #close the parent popup
         self.parentWidget.close()

--- a/main.py
+++ b/main.py
@@ -94,7 +94,6 @@ class GroundControlApp(App):
         if self.config.get('Advanced Settings', 'encoderSteps') == '8148.0':
             self.data.message_queue.put("Message: This update will adjust the the number of encoder pulses per rotation from 8,148 to 8,113 in your settings which improves the positional accuracy.\n\nPerforming a calibration will help you get the most out of this update.")
             self.config.set('Advanced Settings', 'encoderSteps', '8113.73')
-            self.config.write()
         
         self.data.comport = self.config.get('Maslow Settings', 'COMport')
         self.data.gcodeFile = self.config.get('Maslow Settings', 'openFile')


### PR DESCRIPTION
Both are covered by configSettingChange().  The calls to write()
are not that annoying other than taking unnecessary CPU cycles and IO.

The calls to pushSettings can create issues when sending multiple
settings to the machine at once.