### PR TITLE
Add Max Feedrate to Advanced Menu

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -222,6 +222,14 @@ settings = {
             },
             {
                 "type": "string",
+                "title": "Max Feedrate",
+                "desc": "The maximum feedrate in mm/min that machine is capable of sustaining.  Setting this value too high will cause movements to start before the prior movement finishes.",
+                "key": "maxFeedrate",
+                "default": 700,
+                "firmwareKey": 15
+            },
+            {
+                "type": "string",
                 "title": "Home Position X Coordinate",
                 "desc": "The X coordinate of the home position",
                 "key": "homeX",


### PR DESCRIPTION
Not strictly necessary, but given that we are providing a warning to users, we probably want this in GC so that we can help them lower the feedrate if they see warnings.

Also, https://github.com/MaslowCNC/Firmware/pull/409 won't cause an update on the user end, unless they wiped their eeprom or otherwise caused a reset of the settings to their default value.  This change to GC will cause the default value to be pushed to the machine.  