### PR TITLE
Force units to be mm only when setting dist to extend chains

### DIFF
--- a/CalibrationWidgets/measureDistBetweenMotors.py
+++ b/CalibrationWidgets/measureDistBetweenMotors.py
@@ -17,6 +17,7 @@ class MeasureDistBetweenMotors(GridLayout):
         self.targetWidget = target
 
         self.popupContent = TouchNumberInput(done=self.dismiss_popup, data = self.data)
+        self.popupContent.forceUnitsMM()
         self._popup = Popup(title="Set distance to move chain", content=self.popupContent,
                             size_hint=(0.9, 0.9))
         self._popup.open()


### PR DESCRIPTION
The popup gives both options but only mm are valid