### PR TITLE
Add Gero's suggestions for calibration routine

### DIFF
--- a/CalibrationWidgets/calibrationFrameWidget.py
+++ b/CalibrationWidgets/calibrationFrameWidget.py
@@ -107,23 +107,32 @@ class CalibrationFrameWidget(GridLayout):
             self.listOfCalibrationSteps.append(setTo12)
             
         
-        #add extend chains
-        measureOutChains                                = MeasureOutChains()
-        self.listOfCalibrationSteps.append(measureOutChains)
-        
-        #add set z
-        adjustZCalibrationDepth                         = AdjustZCalibrationDepth()
-        self.listOfCalibrationSteps.append(adjustZCalibrationDepth)
-        
         if App.get_running_app().data.config.get('Advanced Settings', 'kinematicsType') == 'Triangular':
             #add rotation radius guess
             rotationRadiusGuess                         = RotationRadiusGuess()
             self.listOfCalibrationSteps.append(rotationRadiusGuess)
+            
+            #add extend chains
+            measureOutChains                                = MeasureOutChains()
+            self.listOfCalibrationSteps.append(measureOutChains)
+            
+            #add set z
+            adjustZCalibrationDepth                         = AdjustZCalibrationDepth()
+            self.listOfCalibrationSteps.append(adjustZCalibrationDepth)
+            
             #add triangular kinematics
             triangularCalibration                       = TriangularCalibration()
             self.listOfCalibrationSteps.append(triangularCalibration)
         else:
-            #this will be done in a separate pull request because I want to test it carefully
+            
+            #add extend chains
+            measureOutChains                                = MeasureOutChains()
+            self.listOfCalibrationSteps.append(measureOutChains)
+            
+            #add set z
+            adjustZCalibrationDepth                         = AdjustZCalibrationDepth()
+            self.listOfCalibrationSteps.append(adjustZCalibrationDepth)
+            
             #Ask for guess of attachment spacing
             distBetweenChainBrackets                    = DistBetweenChainBrackets()
             self.listOfCalibrationSteps.append(distBetweenChainBrackets)

--- a/CalibrationWidgets/measureOutChains.py
+++ b/CalibrationWidgets/measureOutChains.py
@@ -20,7 +20,7 @@ class MeasureOutChains(GridLayout):
         
         '''
         self.data = App.get_running_app().data
-        self.text =  "Now we are going to adjust the chains to a known length\n\nIf your chains are not attached place the first link of the chain on the vertical sprocket tooth\nIf your chains are already in place they may retract to the target length\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\nPressing Next will move the sled to the center of the sheet.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
+        self.text =  "Now we are going to adjust the chains to a known length\n\nIf your chains are not attached place the first link of the chain on the vertical sprocket tooth\nIf your chains are already in place they may retract to the target length\n\nThe correct length of first the left and then the right chain will be measured out\n\nOnce both chains are finished attach the sled, then press Next\n\nThe Move to Center button will move the sled to the center.\n\nBe sure to keep an eye on the chains during this process to ensure that they do not become tangled\naround the sprocket. The motors are very powerful and the machine can damage itself this way"
         
         #select the right image for a given setup
         print "measure out chains on enter"
@@ -36,8 +36,16 @@ class MeasureOutChains(GridLayout):
         with self.data.gcode_queue.mutex:
             self.data.gcode_queue.queue.clear()
     
-    def next(self):
+    def moveToCenter(self):
+        '''
+        
+        Adjusts the chains to the lengths to put the sled in the center of the sheet
+        
+        '''
         self.data.gcode_queue.put("B15 ")
+    
+    def next(self):
+        
         self.readyToMoveOn()
     
     '''

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1264,6 +1264,9 @@
             text: 'Stop'
             on_release: root.stop()
         Button:
+            text: 'Move to Center'
+            on_release: root.moveToCenter()
+        Button:
             text: 'Next'
             on_release: root.next()
         Label:


### PR DESCRIPTION
@GeroBH pointed out that the sled may not actually end up in the middle of the sheet during the calibration process because the calibration process doesn't have a good guess for the rotation radius at this point. 

This PR fixes that issue by moving the part where you enter the rotation radius guess before the step where it moves to the center. It also adds a button to command the sled to move to the center instead of doing it automatically when the step is over which was more confusing.

I'm  not going to merge this one until after the 1.09 release because as much as it seems safe, We've all done a lot of testing on 1.09 to make it stable and I would rather not change anything unless we absolutely have to.