### PR TITLE
Fix hidden adjust z-axis messages during calibration

### DIFF
--- a/main.py
+++ b/main.py
@@ -295,7 +295,6 @@ class GroundControlApp(App):
                 self.data.uploadFlag = 0
                 self.writeToTextConsole(message)
             elif message[0:8] == "Message:":
-                print message
                 if self.data.calibrationInProcess and message[0:15] == "Message: Unable":   #this suppresses the annoying messages about invalid chain lengths during the calibration process
                     break
                 self.previousUploadStatus = self.data.uploadFlag 

--- a/main.py
+++ b/main.py
@@ -295,7 +295,8 @@ class GroundControlApp(App):
                 self.data.uploadFlag = 0
                 self.writeToTextConsole(message)
             elif message[0:8] == "Message:":
-                if self.data.calibrationInProcess:
+                print message
+                if self.data.calibrationInProcess and message[0:15] == "Message: Unable":
                     break
                 self.previousUploadStatus = self.data.uploadFlag 
                 self.data.uploadFlag = 0

--- a/main.py
+++ b/main.py
@@ -296,7 +296,7 @@ class GroundControlApp(App):
                 self.writeToTextConsole(message)
             elif message[0:8] == "Message:":
                 print message
-                if self.data.calibrationInProcess and message[0:15] == "Message: Unable":
+                if self.data.calibrationInProcess and message[0:15] == "Message: Unable":   #this suppresses the annoying messages about invalid chain lengths during the calibration process
                     break
                 self.previousUploadStatus = self.data.uploadFlag 
                 self.data.uploadFlag = 0


### PR DESCRIPTION
The calibration process was hiding the prompt to adjust the z-axis when it is not installed