### PR TITLE
Move choose chain over sprocket direction to after measuring distance between motors

### DIFF
--- a/CalibrationWidgets/calibrationFrameWidget.py
+++ b/CalibrationWidgets/calibrationFrameWidget.py
@@ -45,9 +45,6 @@ class CalibrationFrameWidget(GridLayout):
         intro =  Intro()
         self.listOfCalibrationSteps.append(intro)
         
-        chooseChainOverSprocketDirection             = ChooseChainOverSprocketDirection()
-        self.listOfCalibrationSteps.append(chooseChainOverSprocketDirection)
-        
         chooseKinematicsType                        = ChooseKinematicsType()
         self.listOfCalibrationSteps.append(chooseKinematicsType)
         
@@ -59,6 +56,9 @@ class CalibrationFrameWidget(GridLayout):
         
         measureMotorDist                            = MeasureDistBetweenMotors()
         self.listOfCalibrationSteps.append(measureMotorDist)
+        
+        chooseChainOverSprocketDirection             = ChooseChainOverSprocketDirection()
+        self.listOfCalibrationSteps.append(chooseChainOverSprocketDirection)
         
         reviewMeasurements                          = ReviewMeasurements()
         self.listOfCalibrationSteps.append(reviewMeasurements)


### PR DESCRIPTION
As mentioned in this [forum thread](https://forums.maslowcnc.com/t/calibration-issue/2892/23) asking for the chain over the sprocket direction before measuring the distance between the motors is setting folks up to be confused because measuring the distance between the motors may use the chains in a different way.

Should we move asking the kinematics type and the guess for the vertical distance to the motors down too just to keep them together?