### PR TITLE
Handle special case where an arc is 360 degrees

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -1,6 +1,6 @@
 '''
 
-This module provides a UI element which can display gcode on a Kivy canvas element. It also provides panning 
+This module provides a UI element which can display gcode on a Kivy canvas element. It also provides panning
 and zooming features. It was not originally written as a stand alone module which might create some weirdness.
 
 '''
@@ -21,28 +21,28 @@ import math
 import global_variables
 
 class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
-    
+
     canvasScaleFactor = 1 #scale from mm to pixels
     INCHES            = 25.4
-    MILLIMETERS       = 1 
-    
+    MILLIMETERS       = 1
+
     xPosition = 0
     yPosition = 0
     zPosition = 0
-    
+
     lineNumber = 0  #the line number currently being processed
-    
+
     absoluteFlag = 0
-    
+
     prependString = "G01 "
-    
-    
-    
+
+
+
     def initialize(self):
-        
+
         self.targetIndicator.color   = self.data.targetInicatorColor
         self.positionIndicator.color = self.data.posIndicatorColor
-        
+
         self.drawWorkspace()
 
         if self.data.config.getboolean('Ground Control Settings', 'centerCanvasOnResize'):
@@ -51,39 +51,39 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         self.data.bind(gcode = self.updateGcode)
         self.data.bind(gcodeShift = self.reloadGcode)
         self.data.bind(gcodeFile = self.centerCanvasAndReloadGcode)
-        
+
         global_variables._keyboard = Window.request_keyboard(self._keyboard_closed, self)
         global_variables._keyboard.bind(on_key_down=self._on_keyboard_down)
-        
+
         self.centerCanvasAndReloadGcode()
-    
+
     def addPoint(self, x, y):
         '''
-        
+
         Add a point to the line currently being plotted
-        
+
         '''
 
         self.line.points.extend((x,y))
-    
+
     def _keyboard_closed(self):
         '''
-        
+
         If the window looses focus.
-        
+
         '''
         global_variables._keyboard.unbind(on_key_down=self._on_keyboard_down)
         global_variables._keyboard = None
 
     def _on_keyboard_down(self, keyboard, keycode, text, modifiers):
         '''
-        
+
         Called when a button is pressed.
-        
+
         '''
         scaleFactor = .03
         anchor = (0,0)
-        
+
         if keycode[1] == self.data.config.get('Ground Control Settings', 'zoomIn'):
             mat = Matrix().scale(1-scaleFactor, 1-scaleFactor, 1)
             self.scatterInstance.apply_transform(mat, anchor)
@@ -101,14 +101,14 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
     def centerCanvasAndReloadGcode(self, *args):
         self.centerCanvas()
         self.reloadGcode()
-        
+
     def reloadGcode(self, *args):
         '''
-        
-        This reloads the gcode from the hard drive in case it has been updated. 
-        
+
+        This reloads the gcode from the hard drive in case it has been updated.
+
         '''
-        
+
         filename = self.data.gcodeFile
         if filename is "": #Blank the g-code if we're loading "nothing"
 			self.data.gcode = ""
@@ -137,10 +137,10 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             filtersparsed = [x.replace('I ','I') for x in filtersparsed]
             filtersparsed = [x.replace('J ','J') for x in filtersparsed]
             filtersparsed = [x.replace('F ','F') for x in filtersparsed]
-            
+
             self.data.gcode = "[]"
             self.data.gcode = filtersparsed
-            
+
             filterfile.close() #closes the filter save file
 
             #Find gcode indicies of z moves
@@ -158,31 +158,31 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         except:
             self.data.message_queue.put("Message: Cannot reopen gcode file. It may have been moved or deleted. To locate it or open a different file use Actions > Open G-code")
             self.data.gcodeFile = ""
-    
+
     def centerCanvas(self, *args):
         '''
-        
+
         Return the canvas to the center of the screen.
-        
+
         '''
         mat = Matrix().translate(Window.width/2, Window.height/2, 0)
         self.scatterInstance.transform = mat
-        
+
         anchor = (0,0)
         mat = Matrix().scale(.45, .45, 1)
         self.scatterInstance.apply_transform(mat, anchor)
 
     def on_touch_up(self, touch, *args):
-        
+
         if touch.is_mouse_scrolling:
             self.zoomCanvas(touch)
-        
+
         return super(GcodeCanvas, self).on_touch_up(touch, *args)
-    
+
     def zoomCanvas(self, touch):
         if touch.is_mouse_scrolling:
             scaleFactor = .1
-            
+
             if touch.button == 'scrollup':
                 mat = Matrix().scale(1-scaleFactor, 1-scaleFactor, 1)
                 self.scatterInstance.apply_transform(mat, anchor = touch.pos)
@@ -193,7 +193,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
     def drawWorkspace(self, *args):
 
         self.scatterObject.canvas.remove_group('workspace')
- 
+
         with self.scatterObject.canvas:
             Color(.47, .47, .47)
 
@@ -204,32 +204,32 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             Line(points = ( -width/2 ,  height/2 ,  width/2 ,  height/2), group='workspace')
             Line(points = ( -width/2 , -height/2 , -width/2 ,  height/2), group='workspace')
             Line(points = (  width/2 , -height/2 ,  width/2 ,  height/2), group='workspace')
-            
+
             #create the axis lines
             Line(points = (-width/2,0,width/2,0), dash_offset = 5, group='workspace')
             Line(points = (0, -height/2,0,height/2), dash_offset = 5, group='workspace')
-    
+
     def drawLine(self,gCodeLine,command):
         '''
-        
+
         drawLine draws a line using the previous command as the start point and the xy coordinates
         from the current command as the end point. The line is styled based on the command to allow
         visually differentiating between normal and rapid moves. If the z-axis depth is changed a
-        circle is placed at the location of the depth change to alert the user. 
-    
+        circle is placed at the location of the depth change to alert the user.
+
         '''
-        
+
         try:
             xTarget = self.xPosition
             yTarget = self.yPosition
             zTarget = self.zPosition
-            
+
             x = re.search("X(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if x:
                 xTarget = float(x.groups()[0])*self.canvasScaleFactor
                 if self.absoluteFlag == 1:
                     xTarget = self.xPosition + xTarget
-            
+
             y = re.search("Y(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if y:
                 yTarget = float(y.groups()[0])*self.canvasScaleFactor
@@ -238,22 +238,22 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             z = re.search("Z(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if z:
                 zTarget = float(z.groups()[0])*self.canvasScaleFactor
-            
-            
+
+
             #Draw lines for G1 and G0
             with self.scatterObject.canvas:
                 Color(self.data.drawingColor[0], self.data.drawingColor[1], self.data.drawingColor[2])
-                
+
                 if command == 'G00':
                     #draw a dashed line
                     Line(points = (self.xPosition , self.yPosition , xTarget, yTarget), width = 1, group = 'gcode', dash_length = 4, dash_offset = 2)
-                    
+
                     #start a new straight line from the end of the dashed line
                     self.line = Line(points = (), width = 1, group = 'gcode')
                     self.addPoint(xTarget , yTarget)
                 else:
                     self.addPoint(xTarget , yTarget)
-                
+
             #If the zposition has changed, add indicators
             tol = 0.05 #Acceptable error in mm
             if abs(zTarget - self.zPosition) >= tol:
@@ -266,28 +266,28 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                         radius = 2
                     Line(circle=(self.xPosition , self.yPosition, radius), group = 'gcode')
                     Color(self.data.drawingColor[0], self.data.drawingColor[1], self.data.drawingColor[2])
-            
+
             self.xPosition = xTarget
             self.yPosition = yTarget
             self.zPosition = zTarget
         except:
             print "Unable to draw line on screen: " + gCodeLine
-    
+
     def drawArc(self,gCodeLine,command):
         '''
-        
+
         drawArc draws an arc using the previous command as the start point, the xy coordinates from
         the current command as the end point, and the ij coordinates from the current command as the
-        circle center. Clockwise or counter-clockwise travel is based on the command. 
-    
+        circle center. Clockwise or counter-clockwise travel is based on the command.
+
         '''
-        
+
         try:
             xTarget = self.xPosition
             yTarget = self.yPosition
             iTarget = 0
             jTarget = 0
-            
+
             x = re.search("X(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if x:
                 xTarget = float(x.groups()[0])*self.canvasScaleFactor
@@ -300,22 +300,22 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             j = re.search("J(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if j:
                 jTarget = float(j.groups()[0])*self.canvasScaleFactor
-            
+
             radius = math.sqrt(iTarget**2 + jTarget**2)
             centerX = self.xPosition + iTarget
             centerY = self.yPosition + jTarget
-            
+
             angle1 = math.atan2(self.yPosition - centerY, self.xPosition - centerX)
             angle2 = math.atan2(yTarget - centerY, xTarget - centerX)
-            
-            
+
+
             #atan2 returns results from -pi to +pi and we want results from 0 - 2pi
             if angle1 < 0:
                 angle1 = angle1 + 2*math.pi
             if angle2 < 0:
                 angle2 = angle2 + 2*math.pi
-            
-            
+
+
             #take into account command G1 or G2
             if int(command[1:]) == 2:
                 if angle1 < angle2:
@@ -325,18 +325,20 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                 if angle2 < angle1:
                     angle2 = angle2 + 2*math.pi
                 direction = 1
-            
+
             arcLen = abs(angle1 - angle2)
-            
+            if abs(angle1 - angle2) == 0:
+                arcLen = 360
+
             i = 0
             while abs(i) < arcLen:
                 xPosOnLine = centerX + radius*math.cos(angle1 + i)
                 yPosOnLine = centerY + radius*math.sin(angle1 + i)
                 self.addPoint(xPosOnLine , yPosOnLine)
-                i = i+.1*direction #this is going to need to be a direction 
-            
+                i = i+.1*direction #this is going to need to be a direction
+
             self.addPoint(xTarget , yTarget)
-            
+
             self.xPosition = xTarget
             self.yPosition = yTarget
         except:
@@ -344,202 +346,201 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
 
     def clearGcode(self):
         '''
-        
-        clearGcode deletes the lines and arcs corresponding to gcode commands from the canvas. 
-    
+
+        clearGcode deletes the lines and arcs corresponding to gcode commands from the canvas.
+
         '''
         self.scatterObject.canvas.clear()#remove_group('gcode')
-        
+
         self.drawWorkspace()
-    
+
     def moveToPos(self, xPosition, yPosition, *args):
         '''
-        
+
         Move the machine to a point selected on the screen
-        
+
         '''
         if self.data.units == 'MM':
             scaleFactor = 1
         else:
             scaleFactor = 25.4
-        
+
         xTarget = '%.3f'%(xPosition/scaleFactor)
         yTarget = '%.3f'%(yPosition/scaleFactor)
         commandString = 'G0 X' + str(xTarget) + ' Y' + str(yTarget) + " "
-        
+
         self.data.gcode_queue.put(commandString)
-    
+
     def createMark(self, xPosition, yPosition, *args):
         '''
-        
+
         Create a mark at a point selected on the screen
-        
+
         '''
-        
+
         if self.data.units == 'MM':
             scaleFactor = 1
         else:
             scaleFactor = 25.4
-        
+
         xTarget = xPosition/scaleFactor
         yTarget = yPosition/scaleFactor
         marker = PositionIndicator()
         marker.setPos(xTarget, yTarget, self.data.units)
         marker.color = (0,1,0)
         self.scatterInstance.add_widget(marker)
-    
+
     def doNothing(self, *args):
         '''
-        
+
         A placeholder function which does nothing
-        
+
         '''
         pass
-    
+
     def moveLine(self, gCodeLine):
-        
+
         originalLine = gCodeLine
-        
+
         try:
             gCodeLine = gCodeLine.upper() + " "
-            
+
             x = re.search("X(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if x:
                 xTarget = float(x.groups()[0]) + self.data.gcodeShift[0]
                 gCodeLine = gCodeLine[0:x.start()+1] + str(xTarget) + gCodeLine[x.end():]
-            
+
             y = re.search("Y(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if y:
                 yTarget = float(y.groups()[0]) + self.data.gcodeShift[1]
                 gCodeLine = gCodeLine[0:y.start()+1] + str(yTarget) + gCodeLine[y.end():]
-            
+
             return gCodeLine
         except ValueError:
             print "line could not be moved:"
             print originalLine
             return originalLine
-    
+
     def loadNextLine(self):
         '''
-        
+
         Load the next line of gcode
-        
+
         '''
-        
+
         try:
             self.data.gcode[self.lineNumber] = self.moveLine(self.data.gcode[self.lineNumber])    #move the line if the gcode has been moved
             fullString = self.data.gcode[self.lineNumber]
             self.lineNumber = self.lineNumber + 1
         except:
             return #we have reached the end of the file
-        
+
         #if the line contains multiple gcode commands split them and execute them individually
         listOfLines = fullString.split('G')
-        
+
         if len(listOfLines) > 1:                              #if the line contains at least one 'G'
             for line in listOfLines:
                 if len(line) > 0:                                   #If the line is not blank
                     self.updateOneLine('G' + line)                     #Draw it
         else:
             self.updateOneLine(fullString)
-        
+
     def updateOneLine(self, fullString):
         '''
-        
+
         Draw the next line on the gcode canvas
-        
+
         '''
-        
+
         validPrefixList = ['G00','G0 ','G1 ','G01','G2 ','G02','G3 ','G03', 'G17']
-        
+
         fullString = fullString + " " #ensures that there is a space at the end of the line
-        
+
         #find 'G' anywhere in string
         gString = fullString[fullString.find('G'):fullString.find('G') + 3]
-        
+
         if gString in validPrefixList:
             self.prependString = gString
-        
+
         if fullString.find('G') == -1: #this adds the gcode operator if it is omitted by the program
             fullString = self.prependString + ' ' + fullString
             gString = self.prependString
-        
+
         if gString == 'G00' or gString == 'G0 ':
             self.drawLine(fullString, 'G00')
 
         if gString == 'G01' or gString == 'G1 ':
             self.drawLine(fullString, 'G01')
-                    
+
         if gString == 'G02' or gString == 'G2 ':
             self.drawArc(fullString, 'G02')
-                           
+
         if gString == 'G03' or gString == 'G3 ':
             self.drawArc(fullString, 'G03')
-        
+
         if gString == 'G17':
             #Take no action, XY coordinate plane is the default
             pass
-        
+
         if gString == 'G18':
             print "G18 not supported"
-        
+
         if gString == 'G20':
             self.canvasScaleFactor = self.INCHES
             self.data.units = "INCHES"
-            
+
         if gString == 'G21':
             self.canvasScaleFactor = self.MILLIMETERS
             self.data.units = "MM"
-        
+
         if gString == 'G90':
             self.absoluteFlag = 0
-            
+
         if gString == 'G91':
             self.absoluteFlag = 1
-        
+
     def callBackMechanism(self, callback) :
         '''
-        
+
         Call the loadNextLine function periodically in a non-blocking way to
         update the gcode.
-        
+
         '''
-        
+
         with self.scatterObject.canvas:
             self.line = Line(points = (), width = 1, group = 'gcode')
-        
+
         #Draw numberOfTimesToCall lines on the canvas
         numberOfTimesToCall = 500
         for _ in range(numberOfTimesToCall):
             self.loadNextLine()
-        
+
         #Repeat until end of file
         if self.lineNumber < min(len(self.data.gcode),60000):
             Clock.schedule_once(self.callBackMechanism)
-    
+
     def updateGcode(self, *args):
         '''
-        
-        updateGcode parses the gcode commands and calls the appropriate drawing function for the 
-        specified command. 
-    
+
+        updateGcode parses the gcode commands and calls the appropriate drawing function for the
+        specified command.
+
         '''
-        
-        #reset variables 
+
+        #reset variables
         self.xPosition = self.data.gcodeShift[0]*self.canvasScaleFactor
         self.yPosition = self.data.gcodeShift[1]*self.canvasScaleFactor
         self.zPosition = 0
 
         self.prependString = "G00 "
         self.lineNumber = 0
-        
+
         self.clearGcode()
-        
+
         #Check to see if file is too large to load
         if len(self.data.gcode) > 60000:
             errorText = "The current file contains " + str(len(self.data.gcode)) + " lines of gcode.\nrendering all " +  str(len(self.data.gcode)) + " lines simultaneously may crash the\n program, only the first 60000 lines are shown here.\nThe complete program will cut if you choose to do so."
             print errorText
             self.data.message_queue.put("Message: " + errorText)
-        
+
         self.callBackMechanism(self.updateGcode)
-        

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -328,7 +328,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
 
             arcLen = abs(angle1 - angle2)
             if abs(angle1 - angle2) == 0:
-                arcLen = 360
+                arcLen = 6.28313530718
 
             i = 0
             while abs(i) < arcLen:


### PR DESCRIPTION
This addresses issue #672:
If the starting XY and ending XY of a G02 or G03 code are identical, the circle will not be rendered on the gcodeCanvas. When that same line is sent to the firmware, it will be correctly processed.
 Fixed the previous trig error, arcLen is in radians instead of degrees...