### PR TITLE
Correct rendering error wnen the arc to render is a full circle

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -327,6 +327,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                 direction = 1
             
             arcLen = abs(angle1 - angle2)
+            if abs(angle1 - angle2) == 0:
+                arcLen = 6.28313530718
             
             i = 0
             while abs(i) < arcLen:


### PR DESCRIPTION
This addresses issue #672:
If the starting XY and ending XY of a G02 or G03 code are identical, the circle will not be rendered on the gcodeCanvas. When that same line is sent to the firmware, it will be correctly processed.
Fixed the previous trig error, arcLen is in radians instead of degrees...