### PR TITLE
Address issue #672   g02 and g03 rendering error

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -327,6 +327,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
                 direction = 1
             
             arcLen = abs(angle1 - angle2)
+            if abs(angle1 - angle2) == 0:
+                arcLen = 6.28313530718
             
             i = 0
             while abs(i) < arcLen:

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -407,12 +407,12 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             
             x = re.search("X(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if x:
-                xTarget = float(x.groups()[0]) + self.data.gcodeShift[0]
+                xTarget = '%f' % (float(x.groups()[0]) + self.data.gcodeShift[0])
                 gCodeLine = gCodeLine[0:x.start()+1] + str(xTarget) + gCodeLine[x.end():]
             
             y = re.search("Y(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if y:
-                yTarget = float(y.groups()[0]) + self.data.gcodeShift[1]
+                yTarget = '%f' % (float(y.groups()[0]) + self.data.gcodeShift[1])
                 gCodeLine = gCodeLine[0:y.start()+1] + str(yTarget) + gCodeLine[y.end():]
             
             return gCodeLine

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -404,16 +404,27 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         
         try:
             gCodeLine = gCodeLine.upper() + " "
-            
             x = re.search("X(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if x:
-                xTarget = '%f' % (float(x.groups()[0]) + self.data.gcodeShift[0])
-                gCodeLine = gCodeLine[0:x.start()+1] + str(xTarget) + gCodeLine[x.end():]
+#                 xTarget = '%f' % (float(x.groups()[0]) + self.data.gcodeShift[0]) # not used any more...
+                eNtnX = re.sub('\-?\d\.|\d*e-','',str(abs(float(x.groups()[0]) + self.data.gcodeShift[0]))) # strip off everything but the decimal part or e-notation exponent
+                e = re.search(".*e-", str(abs(float(x.groups()[0]) + self.data.gcodeShift[0])))
+                if e:
+                    fmtX = "%0%.%sf" % eNtnX  # if e-notation, use the exponent from the e notation
+                else:
+                    fmtX = "%0%.%sf" % len(eNtnX) # use the number of digits after the decimal place
+                gCodeLine = gCodeLine[0:x.start()+1] + (fmtX % (float(x.groups()[0]) + self.data.gcodeShift[0])) + gCodeLine[x.end():]
             
             y = re.search("Y(?=.)(([ ]*)?[+-]?([0-9]*)(\.([0-9]+))?)", gCodeLine)
             if y:
-                yTarget = '%f' % (float(y.groups()[0]) + self.data.gcodeShift[1])
-                gCodeLine = gCodeLine[0:y.start()+1] + str(yTarget) + gCodeLine[y.end():]
+#                 yTarget = '%f' % (float(y.groups()[0]) + self.data.gcodeShift[1]) # not used any more...
+                eNtnY = re.sub('\-?\d\.|\d*e-','',str(abs(float(y.groups()[0]) + self.data.gcodeShift[1])))
+                e = re.search(".*e-", str(abs(float(y.groups()[0]) + self.data.gcodeShift[1])))
+                if e:
+                    fmtY = "%0%.%sf" % eNtnY
+                else:
+                    fmtY = "%0%.%sf" % len(eNtnY)
+                gCodeLine = gCodeLine[0:y.start()+1] + (fmtY % (float(y.groups()[0]) + self.data.gcodeShift[1])) + gCodeLine[y.end():]
             
             return gCodeLine
         except ValueError:


### PR DESCRIPTION
I've added code that handles X and Y parameters with 12 or fewer decimal places, converting the e-notation to a decimal string with the appropriate number of digits for that one parameter. Longer parameters are truncated at 12 places. The fix is centered in the code where changes to the home coordinates combine with the X and Y parameters. The 12 decimal place limit includes those added by the new home coordinates.
 This should correctly handle input from programs that use insanely long parameters, but it doesn't address the issue of string length for a gcode line other than only giving each parameter the number of decimal places it had in the source file. Handling unreasonable input files would be better handled elsewhere. 