### PR TITLE
Add chain tolerance parameters

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -189,6 +189,20 @@ settings = {
                 "default": 6.35
             },
             {
+                "type": "string",
+                "title": "Chain Tolerance, Left Chain",
+                "desc": "The tolerance adjustment for the left chain length, in percent",
+                "key": "leftChainTolerance",
+                "default": 0
+            },
+            {
+                "type": "string",
+                "title": "Chain Tolerance, Right Chain",
+                "desc": "The tolerance adjustment for the right chain length, in percent",
+                "key": "rightChainTolerance",
+                "default": 0
+            },
+            {
                 "type": "options",
                 "title": "Side of Motor Sprockets That Chains Go to Sled",
                 "desc": "On which side of the motor sprockets the chains connect to the sled",
@@ -474,6 +488,16 @@ settings = {
                 "type": "string",
                 "key": "fPWMComputed",
                 "firmwareKey": 39
+            },
+            {
+                "type": "string",
+                "key": "distPerRotLeftChainTolerance",
+                "firmwareKey": 40
+            },
+            {
+                "type": "string",
+                "key": "distPerRotRightChainTolerance",
+                "firmwareKey": 41
             }
         ]
 }

--- a/main.py
+++ b/main.py
@@ -158,6 +158,13 @@ class GroundControlApp(App):
         elif (key == 'gearTeeth' or key == 'chainPitch') and self.config.has_option('Advanced Settings', 'gearTeeth') and self.config.has_option('Advanced Settings', 'chainPitch'):
             distPerRot = float(self.config.get('Advanced Settings', 'gearTeeth')) * float(self.config.get('Advanced Settings', 'chainPitch'))
             self.config.set('Computed Settings', "distPerRot", str(distPerRot))
+
+            if self.config.has_option('Advanced Settings', 'leftChainTolerance'):
+                distPerRotLeftChainTolerance = (1 + (float(self.config.get('Advanced Settings', 'leftChainTolerance')) / 100)) * float(self.config.get('Advanced Settings', 'gearTeeth')) * float(self.config.get('Advanced Settings', 'chainPitch'))
+                self.config.set('Computed Settings', "distPerRotLeftChainTolerance", str(distPerRotLeftChainTolerance))
+            if self.config.has_option('Advanced Settings', 'rightChainTolerance'):
+                distPerRotRightChainTolerance = (1 + (float(self.config.get('Advanced Settings', 'rightChainTolerance')) / 100)) * float(self.config.get('Advanced Settings', 'gearTeeth')) * float(self.config.get('Advanced Settings', 'chainPitch'))
+                self.config.set('Computed Settings', "distPerRotRightChainTolerance", str(distPerRotRightChainTolerance))
         
         elif key == 'leftChainTolerance' and self.config.has_option('Advanced Settings', 'leftChainTolerance') and self.config.has_option('Computed Settings', 'distPerRot'):
             distPerRotLeftChainTolerance = (1 + (float(self.config.get('Advanced Settings', 'leftChainTolerance')) / 100)) * float(self.config.get('Computed Settings', 'distPerRot'))

--- a/main.py
+++ b/main.py
@@ -159,6 +159,14 @@ class GroundControlApp(App):
             distPerRot = float(self.config.get('Advanced Settings', 'gearTeeth')) * float(self.config.get('Advanced Settings', 'chainPitch'))
             self.config.set('Computed Settings', "distPerRot", str(distPerRot))
         
+        elif key == 'leftChainTolerance' and self.config.has_option('Advanced Settings', 'leftChainTolerance') and self.config.has_option('Computed Settings', 'distPerRot'):
+            distPerRotLeftChainTolerance = (1 + (float(self.config.get('Advanced Settings', 'leftChainTolerance')) / 100)) * float(self.config.get('Computed Settings', 'distPerRot'))
+            self.config.set('Computed Settings', "distPerRotLeftChainTolerance", str(distPerRotLeftChainTolerance))
+        
+        elif key == 'rightChainTolerance' and self.config.has_option('Advanced Settings', 'rightChainTolerance') and self.config.has_option('Computed Settings', 'distPerRot'):
+            distPerRotRightChainTolerance = (1 + (float(self.config.get('Advanced Settings', 'rightChainTolerance')) / 100)) * float(self.config.get('Computed Settings', 'distPerRot'))
+            self.config.set('Computed Settings', "distPerRotRightChainTolerance", str(distPerRotRightChainTolerance))
+        
         elif key == 'enablePosPIDValues':
             for key in ('KpPos', 'KiPos', 'KdPos', 'propWeight'):
                 if int(self.config.get('Advanced Settings', 'enablePosPIDValues')) == 1:


### PR DESCRIPTION
This adds the chain tolerance parameters, calculates the new distPerRotation values, and sends them to the firmware.

This is the first GC update for Firmware [422](https://github.com/MaslowCNC/Firmware/pull/422).