### PR TITLE
Make settings page update when it is opened

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -513,7 +513,8 @@ def getJSONSettingSection(section):
     for option in options:
         option['section'] = section
         if 'desc' in option and 'default' in option:
-            option['desc'] += "\ndefault setting: " + str(option['default'])
+            if not "default setting:" in option['desc']:                            #check to see if the default text has already been added
+                option['desc'] += "\ndefault setting: " + str(option['default'])
     return json.dumps(options)
 
 def getDefaultValueSection(section):

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -156,9 +156,12 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         currentSettingsFile = App.get_running_app().get_application_config()
         newSettingsFile = currentSettingsFile.replace("groundcontrol","groundcontrolbackup" + time.strftime("%Y%m%d-%H%M%S"))
         
-        print newSettingsFile
-        
         os.rename(currentSettingsFile, newSettingsFile)
+        
+        #close ground control
+        app = App.get_running_app()
+        app.stop()
+        
         
     def advancedOptionsFunctions(self, text):
         

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -5,7 +5,10 @@ from kivy.uix.popup                                 import    Popup
 from CalibrationWidgets.calibrationFrameWidget      import    CalibrationFrameWidget
 from Simulation.simulationCanvas                    import    SimulationCanvas
 from kivy.clock                                     import    Clock
+from   kivy.app                                     import    App
 import sys
+import os
+import time
 
 class Diagnostics(FloatLayout, MakesmithInitFuncs):
     
@@ -143,6 +146,20 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
         self.data.gcodeFile = "./gcodeForTesting/Calibration Benchmark Test.nc"
         self.parentWidget.close()
     
+    def resetAllSettings(self):
+        '''
+        
+        Renames the groundcontrol.ini file which resets all the settings to the default values
+        
+        '''
+        
+        currentSettingsFile = App.get_running_app().get_application_config()
+        newSettingsFile = currentSettingsFile.replace("groundcontrol","groundcontrolbackup" + time.strftime("%Y%m%d-%H%M%S"))
+        
+        print newSettingsFile
+        
+        os.rename(currentSettingsFile, newSettingsFile)
+        
     def advancedOptionsFunctions(self, text):
         
         if   text == "Test Feedback System":
@@ -157,3 +174,5 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
             self.loadCalibrationBenchmarkTest()
         elif text == "Run Triangular Test Cut Pattern":
             self.runJustTriangularCuts()
+        elif text == "Reset settings to defaults":
+            self.resetAllSettings()

--- a/UIElements/runMenu.py
+++ b/UIElements/runMenu.py
@@ -11,6 +11,7 @@ class RunMenu(FloatLayout):
         from kivy.app import App
         App.get_running_app().stop()
     
+    
     def returnToCenter(self):
         
         self.data.gcode_queue.put("G90  ")

--- a/UIElements/screenControls.py
+++ b/UIElements/screenControls.py
@@ -28,7 +28,7 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         '''
         
         #force the settings panel to update
-        #App.get_running_app().destroy_settings()
+        App.get_running_app().destroy_settings()
         
         #open the settings panel
         App.get_running_app().open_settings()

--- a/UIElements/screenControls.py
+++ b/UIElements/screenControls.py
@@ -3,6 +3,7 @@ from kivy.uix.popup                            import   Popup
 from UIElements.otherFeatures                  import   OtherFeatures
 from DataStructures.makesmithInitFuncs         import   MakesmithInitFuncs
 from UIElements.buttonTemplate                 import   ButtonTemplate
+from kivy.app                                  import   App
 
 
 class ScreenControls(FloatLayout, MakesmithInitFuncs):
@@ -18,6 +19,19 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         self.actionsBtn.textColor                = self.data.fontColor
         self.settingsBtn.btnBackground           = self.data.iconPath + 'Generic.png'
         self.settingsBtn.textColor               = self.data.fontColor
+    
+    def openSettings(self):
+        '''
+        
+        Open the settings panel to manually change settings
+        
+        '''
+        
+        #force the settings panel to update
+        #App.get_running_app().destroy_settings()
+        
+        #open the settings panel
+        App.get_running_app().open_settings()
     
     def show_actions(self):
         '''

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -385,7 +385,7 @@
             Spinner:
                 id: advancedOptions
                 text: "Advanced"
-                values: ["Set Chain Length - Manual", "Wipe EEPROM", "Simulation", "Load Calibration Benchmark Test", "Run Triangular Test Cut Pattern"]
+                values: ["Set Chain Length - Manual", "Wipe EEPROM", "Simulation", "Load Calibration Benchmark Test", "Run Triangular Test Cut Pattern", "Reset settings to defaults"]
                 on_text: root.advancedOptionsFunctions(advancedOptions.text)
 
 <OtherFeatures>:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -40,7 +40,7 @@
             id: actionsBtn
         ButtonTemplate:
             text: "Settings"
-            funcToCallOnRelease: app.open_settings
+            funcToCallOnRelease: root.openSettings
             id: settingsBtn
 
 <GcodeCanvas>:

--- a/main.py
+++ b/main.py
@@ -208,8 +208,11 @@ class GroundControlApp(App):
 
     def configSettingChange(self, section, key, value):
         """
+        
         Respond to changes in the configuration.
+        
         """
+        
         # Update GC things
         if section == "Maslow Settings":
             if key == "COMport":


### PR DESCRIPTION
Force the settings window to stay up to date with settings changed elseware by deleting it right before it opens...it opens slow now but at least it's right 😁

The PR builds off of #690 