### PR TITLE
Fix darwin reset view command

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -395,6 +395,13 @@ settings = {
                 "desc": "Valid file extensions for Ground Control to open. Comma separated list.",
                 "key": "validExtensions",
                 "default": ".nc, .ngc, .text, .gcode"
+            },
+            {
+                "type": "string",
+                "title": "Reset View Scale",
+                "desc": "Zoom scale for 'Reset View' command.",
+                "key": "viewScale",
+                "default": ".45"
             }
         ],
     "Computed Settings": #These are setting calculated from the user inputs on other settings, they are not direclty seen by the user

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -19,6 +19,7 @@ from UIElements.modernMenu                   import ModernMenu
 import re
 import math
 import global_variables
+import sys
 
 class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
     
@@ -169,7 +170,11 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         self.scatterInstance.transform = mat
         
         anchor = (0,0)
-        mat = Matrix().scale(.45, .45, 1)
+        if sys.platform.startswith('darwin'):
+            mat = Matrix().scale(.9, .9, 1)
+        else:
+            mat = Matrix().scale(.45, .45, 1)
+
         self.scatterInstance.apply_transform(mat, anchor)
 
     def on_touch_up(self, touch, *args):

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -170,12 +170,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         mat = Matrix().translate(Window.width/2, Window.height/2, 0)
         self.scatterInstance.transform = mat
         
-        scale = self.data.config.get('Ground Control Settings', 'viewScale')
         anchor = (0,0)
-        if sys.platform.startswith('darwin'):
-            mat = Matrix().scale(.9, .9, 1)
-        else:
-            mat = Matrix().scale(.45, .45, 1)
+        scale = self.data.config.get('Ground Control Settings', 'viewScale')
         mat = Matrix().scale(dp(scale), dp(scale), 1)
 
         self.scatterInstance.apply_transform(mat, anchor)

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -15,6 +15,7 @@ from UIElements.viewMenu                     import ViewMenu
 from kivy.graphics.transformation            import Matrix
 from kivy.core.window                        import Window
 from UIElements.modernMenu                   import ModernMenu
+from kivy.metrics                            import dp
 
 import re
 import math
@@ -169,11 +170,13 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         mat = Matrix().translate(Window.width/2, Window.height/2, 0)
         self.scatterInstance.transform = mat
         
+        scale = self.data.config.get('Ground Control Settings', 'viewScale')
         anchor = (0,0)
         if sys.platform.startswith('darwin'):
             mat = Matrix().scale(.9, .9, 1)
         else:
             mat = Matrix().scale(.45, .45, 1)
+        mat = Matrix().scale(dp(scale), dp(scale), 1)
 
         self.scatterInstance.apply_transform(mat, anchor)
 


### PR DESCRIPTION
Use dp() to properly scale screen for gcodeCanvas::centerCanvas().

Also introduce a GroundControl setting for the zoom factor in centerCanvas() as used in 'Reset View'. Love that re-worked settings interface!