### PR TITLE
add positionErrorLimit to Advanced pane

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -364,6 +364,14 @@ settings = {
                 "options": ["490Hz", "4,100Hz", "31,000Hz"],
                 "default": "490Hz",
                 "key": "fPWM",
+            },
+            {
+                "type": "string",
+                "title": "Position Error Limit",
+                "desc": "If the position of the sled varies from the expected position by more than this amount, cutting wil be stopped. Program must be restarted to take effect.",
+                "key": "positionErrorLimit",
+                "default": 2.0,
+                "firmwareKey": 42
             }
         ],
     "Ground Control Settings":


### PR DESCRIPTION
Firmware PR#429 adds an alarm for situations where the position error violates a limit. This will alow the user to change the limit.