### PR TITLE
Add a warning to connect the machine before begining calibration

### DIFF
--- a/CalibrationWidgets/intro.py
+++ b/CalibrationWidgets/intro.py
@@ -17,7 +17,11 @@ class Intro(GridLayout):
         This function runs when the step is entered
         
         '''
-        pass
+        
+        self.data = App.get_running_app().data
+        
+        if self.data.connectionStatus == False:
+            self.data.message_queue.put("Message: The calibration process requres the machine to be connected. To connect to the machine choose Actions -> Ports and select the same port used to install the firmware")
     
     def finished(self):
         self.readyToMoveOn()


### PR DESCRIPTION
I just deleted my .ini file and then tried to start the calibration process which of course didn't work because with the .ini file gone GC won't connect.

This PR adds a warning at the begining fo the calibration process if the machine is not connected.

![image](https://user-images.githubusercontent.com/9359447/38836392-d1a680a4-4182-11e8-9893-0976a0fa65d9.png)
