### PR TITLE
Add Spindle automate options

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -227,11 +227,12 @@ settings = {
                 "firmwareKey": 20
             },
             {
-                "type": "bool",
+                "type": "options",
                 "title": "Spindle Automation",
-                "desc": "How should the spindle start and stop automatically based on gcode? Leave off for default external servo control, on for external relay control.",
+                "desc": "How should the spindle start and stop automatically based on gcode? Leave off for none, or set external servo control, or external relay control, active high or low.",
                 "key": "spindleAutomate",
-                "default": 0,
+		"options": ["None", "Servo", "Relay_High", "Relay_Low"],
+                "default": "None",
                 "firmwareKey": 17
             },
             {

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -569,6 +569,17 @@ def syncFirmwareKey(firmwareKey, value, data):
         for option in settings[section]:
             if 'firmwareKey' in option and option['firmwareKey'] == firmwareKey:
                 storedValue = data.config.get(section, option['key'])
+
+		if (option['key'] == "spindleAutomate"):
+                    if (storedValue == "Servo"):
+                        storedValue = 1
+                    elif (storedValue == "Relay_High"):
+                        storedValue = 2
+                    elif (storedValue == "Relay_Low"):
+                        storedValue = 3
+                    else:
+                        storedValue = 0
+
                 if not isClose(float(storedValue), value):
                     data.gcode_queue.put("$" + str(firmwareKey) + "=" + str(storedValue))
                 else:

--- a/main.py
+++ b/main.py
@@ -235,6 +235,16 @@ class GroundControlApp(App):
         if section == "Advanced Settings":
             if (key == "truncate") or (key == "digits"):
                 self.frontpage.gcodecanvas.reloadGcode()
+            if (key == "spindleAutomate"):
+                if (value == "Servo"):
+                    value = 1
+                elif (value == "Relay_High"):
+                    value = 2
+                elif (value == "Relay_Low"):
+                    value = 3
+                else:
+                    value = 0
+	
         
         # Update Computed Settings
         self.computeSettings(section, key, value)


### PR DESCRIPTION
This is the corresponding update that was added to the firmware to allow for options for how the spindle automate flag is set.  This change converts the spindleAutomate bool option into a drop down menu with 4 options, None, Servo, Relay_High, and Relay_Low.  