### PR TITLE
Add support for buffering on Arduino

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -17,7 +17,7 @@ class SerialPortThread(MakesmithInitFuncs):
     
     machineIsReadyForData      = False # Tracks whether last command was acked
     lastWriteTime              = time.time()
-    bufferSize                 = 256                #The total size of the arduino buffer
+    bufferSize                 = 126                #The total size of the arduino buffer
     bufferSpace                = bufferSize         #The amount of space currently available in the buffer
     lengthOfLastLineStack      =  deque()
     
@@ -98,7 +98,7 @@ class SerialPortThread(MakesmithInitFuncs):
         if float(serial.VERSION[0]) < 3:
             self.data.message_queue.put("Pyserial version 3.x is needed, version " + serial.VERSION + " is installed")
         
-        weAreBufferingLines = self.data.config.get('Maslow Settings', "bufferOn")
+        weAreBufferingLines = bool(int(self.data.config.get('Maslow Settings', "bufferOn")))
         
         try:
             #print("connecting")
@@ -166,9 +166,14 @@ class SerialPortThread(MakesmithInitFuncs):
                         command = self.data.gcode_queue.get_nowait() + " "
                         self._write(command)
                 
-                #Send the next line of gcode to the machine if we're running a program
-                if self.bufferSpace == self.bufferSize and self.machineIsReadyForData: #> len(self.data.gcode[self.data.gcodeIndex]):
-                    self.sendNextLine()
+                #Send the next line of gcode to the machine if we're running a program. Will send lines to buffer if there is space
+                #and the feature is turned on
+                if weAreBufferingLines:
+                    if self.bufferSpace > len(self.data.gcode[self.data.gcodeIndex]): #if there is space in the buffer keep sending lines
+                        self.sendNextLine()
+                else:
+                    if self.bufferSpace == self.bufferSize and self.machineIsReadyForData: #if the receive buffer is empty and the machine has acked the last line complete
+                        self.sendNextLine()
                 
                 
                                             #Check for serial connection loss

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -162,6 +162,13 @@ settings = {
                 "desc": "The vertical distance above the work area to raise the z-axis for safe travel. Used by 'Home', 'Return to Center' and 'z-Axis' settings.",
                 "key": "zAxisSafeHeight",
                 "default": 5,
+            },
+            {
+                "type": "bool",
+                "title": "Buffer Gcode",
+                "desc": "Buffer gcode on arduino to increase execution speed. Requres restart to take effect.",
+                "key": "bufferOn",
+                "default": 0
             }
         ],
     "Advanced Settings":

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -166,7 +166,7 @@ settings = {
             {
                 "type": "bool",
                 "title": "Buffer Gcode",
-                "desc": "Buffer gcode on arduino to increase execution speed. Requres restart to take effect.",
+                "desc": "Buffer gcode on arduino to increase execution speed. Requres restart to take effect. Experimental.",
                 "key": "bufferOn",
                 "default": 0
             }


### PR DESCRIPTION
We have a buffer on board the Arduino which we can use to store lines of gcode ready to be processed. We stopped using it because way back in the dawn of time it was giving us trouble with some computers loosing data over the connection. At the time we were dealing with a lot of issues and it was easier to simply not use the buffer.

Buffering lines of gcode makes a big difference when executing gcode where there are MANY lines over a short distance. It can make a big difference in reducing the cut time for complex parts.

The pull request adds an option to enable buffering of gcode so that we can start to explore it again.

![image](https://user-images.githubusercontent.com/9359447/39322935-225910f6-4940-11e8-9967-c52b8f34046b.png)
