### PR TITLE
Finish first pass at computing the chain tolerance values

### DIFF
--- a/CalibrationWidgets/calibrationFrameWidget.py
+++ b/CalibrationWidgets/calibrationFrameWidget.py
@@ -29,6 +29,7 @@ from CalibrationWidgets.manualCalibration                   import  ManualCalibr
 from CalibrationWidgets.enterDistanceBetweenMotors          import  EnterDistanceBetweenMotors
 from CalibrationWidgets.measureOneChain                     import  MeasureOneChain
 from CalibrationWidgets.computeChainCorrectionFactors       import  ComputeChainCorrectionFactors
+from CalibrationWidgets.wipeOldCorrectionValues             import  WipeOldCorrectionValues
 from   kivy.app                                             import  App
 
 
@@ -177,6 +178,10 @@ class CalibrationFrameWidget(GridLayout):
         #enter manual measurement of distance between motors
         enterDistanceBetweenMotors                       = EnterDistanceBetweenMotors()
         self.listOfCalibrationSteps.append(enterDistanceBetweenMotors)
+        
+        #enter manual measurement of distance between motors
+        wipeOldCorrectionValues                       = WipeOldCorrectionValues()
+        self.listOfCalibrationSteps.append(wipeOldCorrectionValues)
         
         #set to 12
         setTo12                                          = SetSprocketsVertical()

--- a/CalibrationWidgets/computeChainCorrectionFactors.py
+++ b/CalibrationWidgets/computeChainCorrectionFactors.py
@@ -31,9 +31,8 @@ class ComputeChainCorrectionFactors(GridLayout):
             self.selfText.text = ("When measured manually: " + str(self.data.motorsDist) 
                 + "\nWhen measured with the left chain:" + str(self.data.leftChainMeasurement) 
                 + "\nWhen measured with the right chain:" + str(self.data.rightChainMeasurement)
-                + "\nLeft chain correction factor: " + str(self.leftCorrectionFactor)
+                + "\n\nLeft chain correction factor: " + str(self.leftCorrectionFactor)
                 + "\nRight chain correction factor: " + str(self.rightCorrectionFactor)
-                + "\nNote that right now nothing is done with these values"
                 )
         except:
             self.selfText.text = "unable to compute correction factors"

--- a/CalibrationWidgets/computeChainCorrectionFactors.py
+++ b/CalibrationWidgets/computeChainCorrectionFactors.py
@@ -25,21 +25,24 @@ class ComputeChainCorrectionFactors(GridLayout):
         
         try:
         
-            leftCorrectionFactor = (abs(self.data.motorsDist - self.data.leftChainMeasurement)/self.data.leftChainMeasurement)*100.0
-            rightCorrectionFactor = (abs(self.data.motorsDist - self.data.rightChainMeasurement)/self.data.rightChainMeasurement)*100.0
+            self.leftCorrectionFactor = (abs(self.data.motorsDist - self.data.leftChainMeasurement)/self.data.leftChainMeasurement)*100.0
+            self.rightCorrectionFactor = (abs(self.data.motorsDist - self.data.rightChainMeasurement)/self.data.rightChainMeasurement)*100.0
             
             self.selfText.text = ("When measured manually: " + str(self.data.motorsDist) 
                 + "\nWhen measured with the left chain:" + str(self.data.leftChainMeasurement) 
                 + "\nWhen measured with the right chain:" + str(self.data.rightChainMeasurement)
-                + "\nLeft chain correction factor: " + str(leftCorrectionFactor)
-                + "\nRight chain correction factor: " + str(rightCorrectionFactor)
+                + "\nLeft chain correction factor: " + str(self.leftCorrectionFactor)
+                + "\nRight chain correction factor: " + str(self.rightCorrectionFactor)
                 + "\nNote that right now nothing is done with these values"
                 )
         except:
             self.selfText.text = "unable to compute correction factors"
-        
     
     def loadNextStep(self):
+        
+        self.data.config.set('Advanced Settings', 'leftChainTolerance', self.leftCorrectionFactor)
+        self.data.config.set('Advanced Settings', 'rightChainTolerance', self.rightCorrectionFactor)
+        
         self.readyToMoveOn()
     
     def on_Exit(self):

--- a/CalibrationWidgets/measureDistBetweenMotors.py
+++ b/CalibrationWidgets/measureDistBetweenMotors.py
@@ -106,7 +106,7 @@ class MeasureDistBetweenMotors(GridLayout):
     
     def pullChainTight(self):
         #pull the left chain tight
-        self.data.gcode_queue.put("B11 S150 T3 ")
+        self.data.gcode_queue.put("B11 S150 T3 L ")
     
     def on_Enter(self):
         '''

--- a/CalibrationWidgets/measureOneChain.py
+++ b/CalibrationWidgets/measureOneChain.py
@@ -60,7 +60,7 @@ class MeasureOneChain(GridLayout):
     
     def pullChainTight(self):
         #pull the left chain tight
-        self.data.gcode_queue.put("B11 S150 T3 " + self.direction)
+        self.data.gcode_queue.put("B11 S255 T3 " + self.direction)
     
     def on_Enter(self):
         '''

--- a/CalibrationWidgets/wipeOldCorrectionValues.py
+++ b/CalibrationWidgets/wipeOldCorrectionValues.py
@@ -1,0 +1,46 @@
+from   kivy.uix.gridlayout                import   GridLayout
+from   kivy.properties                    import   ObjectProperty
+from   kivy.properties                    import   StringProperty
+from   kivy.app                           import   App
+import global_variables
+
+class WipeOldCorrectionValues(GridLayout):
+    '''
+    
+    Remove the existing values for the chain correction factors to start fresh.
+    
+    '''
+    data                        =  ObjectProperty(None) #linked externally
+    readyToMoveOn               = ObjectProperty(None)
+    
+    def on_Enter(self):
+        '''
+        
+        This function runs when the step is entered
+        
+        '''
+        self.data = App.get_running_app().data
+    
+    
+    def wipeOldSettings(self):
+        '''
+        
+        Set the current values to zero
+        
+        '''
+        
+        self.data.config.set('Advanced Settings', 'leftChainTolerance', 0)
+        self.data.config.set('Advanced Settings', 'rightChainTolerance', 0)
+        
+        self.loadNextStep()
+    
+    def loadNextStep(self):
+        self.readyToMoveOn()
+    
+    def on_Exit(self):
+        '''
+        
+        This function run when the step is completed
+        
+        '''
+        pass

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -976,7 +976,7 @@
         cols: 1
         size_hint_x: leftCol
         Label:
-            text: "Enter the distance from the outside edge of one motor to the other. {picture coming soon}"
+            text: "Enter the distance from the outside edge of one motor to the outside edge of the other motor.\n\nWe measure to the edge because it is easier.\n\n{picture coming soon}"
     GridLayout:
         cols: 1
         size_hint_x: rightCol
@@ -994,6 +994,27 @@
             text: "Enter Values"
             halign: "center"
             on_release: root.enterValues()
+            id: enterValues
+        Label:
+   
+   
+<WipeOldCorrectionValues>:
+    cols: 2
+    width: root.width
+    height: root.height
+    GridLayout:
+        cols: 1
+        size_hint_x: leftCol
+        Label:
+            text: "We need to wipe any existing values for the chain correction values before computing new ones.\n\nThis step will set the values to 0"
+    GridLayout:
+        cols: 1
+        size_hint_x: rightCol
+        Label:
+        Button:
+            text: "Wipe Current\nValues"
+            halign: "center"
+            on_release: root.wipeOldSettings()
             id: enterValues
         Label:
         


### PR DESCRIPTION
The chain tolerance values are now saved to settings at the end of the process.

There is also now an extra step to set the chain tolerance values to zero at the beginning of the process, because they need to be zero for new values to be accurately computed.

This PR also fixes a bug in the regular calibration process which was causing the wrong motor to pull tight. The bug was introduced in the precursor to this PR