### PR TITLE
Add catch for index out of range

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -169,8 +169,11 @@ class SerialPortThread(MakesmithInitFuncs):
                 #Send the next line of gcode to the machine if we're running a program. Will send lines to buffer if there is space
                 #and the feature is turned on
                 if weAreBufferingLines:
-                    if self.bufferSpace > len(self.data.gcode[self.data.gcodeIndex]): #if there is space in the buffer keep sending lines
-                        self.sendNextLine()
+                    try:
+                        if self.bufferSpace > len(self.data.gcode[self.data.gcodeIndex]): #if there is space in the buffer keep sending lines
+                            self.sendNextLine()
+                    except IndexError:
+                        print "index error when reading gcode" #we don't want the whole serial thread to close if the gcode can't be sent because of an index error (file deleted...etc)
                 else:
                     if self.bufferSpace == self.bufferSize and self.machineIsReadyForData: #if the receive buffer is empty and the machine has acked the last line complete
                         self.sendNextLine()


### PR DESCRIPTION
A fix for:

```
 Exception in thread Thread-1:
 Traceback (most recent call last):
   File "C:\Python27\lib\threading.py", line 801, in __bootstrap_inner
[INFO   ] [GL          ] NPOT texture support is available
     self.run()
   File "C:\Python27\lib\threading.py", line 754, in run
     self.__target(*self.__args, **self.__kwargs)
   File "C:\Users\Bar\Git\GroundControl\Connection\serialPortThread.py", line 172, in getmessage
     if self.bufferSpace > len(self.data.gcode[self.data.gcodeIndex]): #if there is space in the buffer keep sending lines
 IndexError: string index out of range
```

The index out of range error isn't a good reason to shut down the whole serial port thread