### PR TITLE
Add 360 degree button to set sprocket vertical panel

### DIFF
--- a/CalibrationWidgets/setSprocketsVertical.py
+++ b/CalibrationWidgets/setSprocketsVertical.py
@@ -14,6 +14,42 @@ class SetSprocketsVertical(GridLayout):
     leftChainLength = 0
     rightchainLength = 0
 
+    def LeftCW360(self):
+        degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/1.0;
+        self.data.gcode_queue.put("G91 ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        self.data.gcode_queue.put("G90 ")
+
+    def RightCW360(self):
+        degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/1.0;
+        self.data.gcode_queue.put("G91 ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        self.data.gcode_queue.put("G90 ")
+
+    def LeftCCW360(self):
+        degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/1.0;
+        self.data.gcode_queue.put("G91 ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 L-"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 L"+str(degValue)+" ")
+        self.data.gcode_queue.put("G90 ")
+
+    def RightCCW360(self):
+        degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/1.0;
+        self.data.gcode_queue.put("G91 ")
+        if self.data.config.get('Advanced Settings', 'chainOverSprocket') == 'Top':
+            self.data.gcode_queue.put("B09 R"+str(degValue)+" ")
+        else:
+            self.data.gcode_queue.put("B09 R-"+str(degValue)+" ")
+        self.data.gcode_queue.put("G90 ")
+
     def LeftCW(self):
         degValue = float(self.data.config.get('Advanced Settings',"gearTeeth"))*float(self.data.config.get('Advanced Settings',"chainPitch"))/360.0;
         self.data.gcode_queue.put("G91 ")

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1,4 +1,4 @@
-#kivy 1.9.9
+#:kivy 1.9.9
 
 #<Widget>:
 #This can be used to create boxes around each widget to clarify positioning issues. It is only for debug
@@ -604,7 +604,7 @@
                 text: "Absolute"
                 size_hint_y: 0.2
             Button:
-                text: "%.2f"%app.data.zStepSizeVal
+                text: "%.3f"%app.data.zStepSizeVal
                 id: distBtn
                 on_release: root.setDist()
             Button:

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1,4 +1,4 @@
-#:kivy 1.9.9
+#kivy 1.9.9
 
 #<Widget>:
 #This can be used to create boxes around each widget to clarify positioning issues. It is only for debug
@@ -604,7 +604,7 @@
                 text: "Absolute"
                 size_hint_y: 0.2
             Button:
-                text: "%.3f"%app.data.zStepSizeVal
+                text: "%.2f"%app.data.zStepSizeVal
                 id: distBtn
                 on_release: root.setDist()
             Button:
@@ -1339,13 +1339,17 @@
         cols:1
         size_hint_x: .4
         GridLayout:
-            cols: 3
+            cols: 4
             size_hint_x: .4
             Label:
                 text: "Left Sprocket"
                 font_size: '20sp'
             Label:
             Label:
+            Label:
+            Button:
+                text: '360 deg CCW'
+                on_release: root.LeftCCW360()
             Button:
                 text: '5 deg CCW'
                 on_release: root.LeftCCW5()
@@ -1355,6 +1359,9 @@
             Button:
                 text: '0.1 deg CCW'
                 on_release: root.LeftCCWpoint1()
+            Button:
+                text: '360 deg CW'
+                on_release: root.LeftCW360()
             Button:
                 text: '5 deg CW'
                 on_release: root.LeftCW5()
@@ -1369,6 +1376,10 @@
                 font_size: '20sp'
             Label:
             Label:
+            Label:
+            Button:
+                text: '360 deg CCW'
+                on_release: root.RightCCW360()
             Button:
                 text: '5 deg CCW'
                 on_release: root.RightCCW5()
@@ -1379,6 +1390,9 @@
                 text: '0.1 deg CCW'
                 on_release: root.RightCCWpoint1()
             Button:
+                text: '360 deg CW'
+                on_release: root.RightCW360()
+            Button:
                 text: '5 deg CW'
                 on_release: root.RightCW5()
             Button:
@@ -1387,6 +1401,10 @@
             Button:
                 text: '0.1 deg CW'
                 on_release: root.RightCWpoint1()
+            Label:
+            Label:
+            Label:
+            Label:
             Button:
                 text: "Automatic"
                 on_release: root.setVerticalAutomatic()


### PR DESCRIPTION
Calibrating a non-stock z motor is simplified by the z-axis control which allows commanding an arbitrary distance to move. Calibrating a non-stock chain motor is possible using the setSprocketVertical panel of the chain calibration tool, but is presently limited to at most a 5 degree movement per button press.
A clean and easy way to improve this is to add a 360-degree button to the present 5-, 1- and 0.1-degree buttons.

<img width="1422" alt="screen shot 2018-06-10 at 12 32 38 pm" src="https://user-images.githubusercontent.com/1851315/41205556-6d08e2a6-6caa-11e8-8f41-843a88e1152f.png">
