### PR TITLE
Fix version spec in groundcontrol.kv

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1,4 +1,4 @@
-#:kivy 1.9.9
+#:kivy 1.9.1
 
 #<Widget>:
 #This can be used to create boxes around each widget to clarify positioning issues. It is only for debug


### PR DESCRIPTION
PR#730 included a housekeeping change to groundcontrol.kv that corrected the file header, adding a colon after the octothorpe. Before that the header was ignored, but with the change the version number in the header becomes required for kivy to run.
 Some time in the past the number in the header line was changed to 1.9.9, which is not one of the valid downloadable versions at kivy.org/downloads - v1.9.1 is the last one before 10.1.0
 Setting the version number in this header to 1.9.1 will allow users with the 1.9.1 version to continue to use that version, and does not affect users with newer versions of Kivy. **It is also required for the OSX version, which packages 1.9.1 in the executable.**


 An alternative could be to revert the change to let kivy ignore the version number, which seems to have worked without problem.