### PR TITLE
Address Issue #736 - macOS package does not include .nc files

### DIFF
--- a/buildozer.spec
+++ b/buildozer.spec
@@ -25,7 +25,7 @@ package.domain = maslowcnc.com
 source.dir = .
 
 # (list) Source files to include (let empty to include all the files)
-source.include_exts = py,png,jpg,kv,atlas
+source.include_exts = py,png,jpg,kv,nc,atlas
 
 # (list) List of inclusions using pattern matching
 #source.include_patterns = assets/*,images/*.png


### PR DESCRIPTION
buildozer filters the file extensions put into the package, '.nc' was not in the list. As a result, the gcodeForTesting directory and its files have been omitted...