### PR TITLE
Add text to Connection Timed Out alert

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -186,6 +186,8 @@ class SerialPortThread(MakesmithInitFuncs):
                     self.data.message_queue.put("Connection Timed Out\n")
                     if self.data.uploadFlag:
                         self.data.message_queue.put("Message: USB connection lost. This has likely caused the machine to loose it's calibration, which can cause erratic behavior. It is recommended to stop the program, remove the sled, and perform the chain calibration process. Press Continue to override and proceed with the cut.")
+                    else:
+                        self.data.message_queue.put("It is possible that the serial port selected is not the one used by the Maslow's Arduino,\nor that the firmware is not loaded on the Arduino.")
                     self.data.connectionStatus = 0
                     self.serialInstance.close()
                     return


### PR DESCRIPTION
Address two common issues with the serial connection:
•wrong port selected
•firmware not loaded