### PR TITLE
Add advanced settings options to set PID values for Z

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -340,6 +340,27 @@ settings = {
             },
             {
                 "type": "string",
+                "title": "Kp Position Z-Axis",
+                "desc": "The proportional constant for the position Z-Axis PID controller",
+                "key": "KpPosZ",
+                "default": 1300
+            },
+            {
+                "type": "string",
+                "title": "Ki Position Z-Axis",
+                "desc": "The integral constant for the position Z-Axis PID controller",
+                "key": "KiPosZ",
+                "default": 0
+            },
+            {
+                "type": "string",
+                "title": "Kd Position Z-Axis",
+                "desc": "The derivative constant for the position Z-Axis PID controller",
+                "key": "KdPosZ",
+                "default": 34
+            },
+            {
+                "type": "string",
                 "title": "Proportional Weighting",
                 "desc": "The ratio of Proportional on Error (1) to Proportional on Measure (0)",
                 "key": "propWeight",
@@ -371,6 +392,27 @@ settings = {
                 "title": "Kd Velocity",
                 "desc": "The derivative constant for the velocity PID controller",
                 "key": "KdV",
+                "default": .28
+            },
+            {
+                "type": "string",
+                "title": "Kp Velocity Z-Axis",
+                "desc": "The proportional constant for the Z-axis velocity PID controller",
+                "key": "KpVZ",
+                "default": 5
+            },
+            {
+                "type": "string",
+                "title": "Ki Velocity Z-Axis",
+                "desc": "The integral constant for the Z-axis velocity PID controller",
+                "key": "KiVZ",
+                "default": 0
+            },
+            {
+                "type": "string",
+                "title": "Kd Velocity Z-Axis",
+                "desc": "The derivative constant for the Z-axis velocity PID controller",
+                "key": "KdVZ",
                 "default": .28
             },
             {

--- a/main.py
+++ b/main.py
@@ -206,6 +206,7 @@ class GroundControlApp(App):
                 else:
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
+            #updated computed values for z-axis
             for key in ('KpVZ', 'KiVZ', 'KdVZ'):
                 self.config.set('Computed Settings', key, value)
         

--- a/main.py
+++ b/main.py
@@ -195,7 +195,9 @@ class GroundControlApp(App):
                 else:
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
-                self.config.set('Computed Settings', key + "Z", value)
+            #updated computed values for z-axis
+            for key in ('KpPosZ', 'KiPosZ', 'KdPosZ', 'propWeight'):
+                self.config.set('Computed Settings', key, value)
 
         elif key == 'enableVPIDValues':
             for key in ('KpV', 'KiV', 'KdV'):
@@ -204,7 +206,8 @@ class GroundControlApp(App):
                 else:
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
-                self.config.set('Computed Settings', key + "Z", value)
+            for key in ('KpVZ', 'KiVZ', 'KdVZ'):
+                self.config.set('Computed Settings', key, value)
         
         elif key == 'chainOverSprocket':
             if value == 'Top':


### PR DESCRIPTION
Adds a settings panel to add options to tune the PID values for the z-axis as requested in this forum thread:

https://forums.maslowcnc.com/t/how-to-make-permanent-changes-to-z-axis-kp-ki-kd/5106/14

![image](https://user-images.githubusercontent.com/9359447/43282332-ac2626a8-90ca-11e8-9fcc-2d84dc261a1f.png)
