### PR TITLE
Make set sprocket vertical buttons text scale correctly

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -1389,27 +1389,59 @@
             Button:
                 text: '360 deg CCW'
                 on_release: root.LeftCCW360()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '5 deg CCW'
                 on_release: root.LeftCCW5()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '1 deg CCW'
                 on_release: root.LeftCCW()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '0.1 deg CCW'
                 on_release: root.LeftCCWpoint1()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '360 deg CW'
                 on_release: root.LeftCW360()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '5 deg CW'
                 on_release: root.LeftCW5()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '1 deg CW'
                 on_release: root.LeftCW()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '0.1 deg CW'
                 on_release: root.LeftCWpoint1()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Label:
                 text: "Right Sprocket"
                 font_size: '20sp'
@@ -1419,27 +1451,59 @@
             Button:
                 text: '360 deg CCW'
                 on_release: root.RightCCW360()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '5 deg CCW'
                 on_release: root.RightCCW5()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '1 deg CCW'
                 on_release: root.RightCCW()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '0.1 deg CCW'
                 on_release: root.RightCCWpoint1()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '360 deg CW'
                 on_release: root.RightCW360()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '5 deg CW'
                 on_release: root.RightCW5()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '1 deg CW'
                 on_release: root.RightCW()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Button:
                 text: '0.1 deg CW'
                 on_release: root.RightCWpoint1()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
             Label:
             Label:
             Label:
@@ -1447,6 +1511,10 @@
             Button:
                 text: "Automatic"
                 on_release: root.setVerticalAutomatic()
+                halign: 'center'
+                valign: 'middle'
+                text_size: self.width, None
+                font_size: self.width * 0.15
         GridLayout:
             cols: 1
             size_hint_x: .4


### PR DESCRIPTION
Makes the text in the set sprocket vertical buttons scale with the button size instead of overflowing onto the other parts of the screen. This was a problem on small screens or when the window was shrunk down.

Here's with half of the buttons fixed:

![capture](https://user-images.githubusercontent.com/9359447/43286985-7a08da4a-90d8-11e8-988f-dc193b2db350.JPG)

Here is how the final version looks:

![image](https://user-images.githubusercontent.com/9359447/43286976-71952404-90d8-11e8-85f0-299ebf344e32.png)
