### PR TITLE
Make stop buttons during calibration red

### DIFF
--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -954,6 +954,7 @@
             text: "Stop\nCut"
             halign: "center"
             on_release: root.stopCut()
+            background_color: (1,.2,.2,1)
         Label:
 
 <ComputeChainCorrectionFactors>:
@@ -1155,6 +1156,7 @@
         Button:
             text: "Stop\nCut"
             on_release: root.stopCut()
+            background_color: (1,.2,.2,1)
         Label:
 
 <MeasureDistBetweenMotors>
@@ -1201,6 +1203,7 @@
         Button:
             text: "Stop\nMotors"
             on_release: root.stopCut()
+            background_color: (1,.2,.2,1)
         Label:
 
 <MeasureOneChain>
@@ -1237,6 +1240,7 @@
         Button:
             text: "Stop\nMotors"
             on_release: root.stopCut()
+            background_color: (1,.2,.2,1)
         Label:
 
 <VertDistToMotorsGuess>:
@@ -1492,6 +1496,7 @@
         Button:
             text: 'Stop'
             on_release: root.stop()
+            background_color: (1,.2,.2,1)
         Button:
             text: 'Move to Center'
             on_release: root.moveToCenter()


### PR DESCRIPTION
After much messing about with trying to use a picture and having it not look good I decided to just make the buttons red. All of the "Stop" button during the calibration process are now red to make them easier to spot. This was suggested in the forums. 

![image](https://user-images.githubusercontent.com/9359447/43288935-46d38f16-90de-11e8-9cf3-0dbd53aab29e.png)
