### PR TITLE
Add PID settings for the z axis (take two)

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -340,6 +340,27 @@ settings = {
             },
             {
                 "type": "string",
+                "title": "Kp Position Z-Axis",
+                "desc": "The proportional constant for the position Z-Axis PID controller",
+                "key": "KpPosZ",
+                "default": 1300
+            },
+            {
+                "type": "string",
+                "title": "Ki Position Z-Axis",
+                "desc": "The integral constant for the position Z-Axis PID controller",
+                "key": "KiPosZ",
+                "default": 0
+            },
+            {
+                "type": "string",
+                "title": "Kd Position Z-Axis",
+                "desc": "The derivative constant for the position Z-Axis PID controller",
+                "key": "KdPosZ",
+                "default": 34
+            },
+            {
+                "type": "string",
                 "title": "Proportional Weighting",
                 "desc": "The ratio of Proportional on Error (1) to Proportional on Measure (0)",
                 "key": "propWeight",
@@ -371,6 +392,27 @@ settings = {
                 "title": "Kd Velocity",
                 "desc": "The derivative constant for the velocity PID controller",
                 "key": "KdV",
+                "default": .28
+            },
+            {
+                "type": "string",
+                "title": "Kp Velocity Z-Axis",
+                "desc": "The proportional constant for the Z-axis velocity PID controller",
+                "key": "KpVZ",
+                "default": 5
+            },
+            {
+                "type": "string",
+                "title": "Ki Velocity Z-Axis",
+                "desc": "The integral constant for the Z-axis velocity PID controller",
+                "key": "KiVZ",
+                "default": 0
+            },
+            {
+                "type": "string",
+                "title": "Kd Velocity Z-Axis",
+                "desc": "The derivative constant for the Z-axis velocity PID controller",
+                "key": "KdVZ",
                 "default": .28
             },
             {

--- a/UIElements/diagnosticsMenu.py
+++ b/UIElements/diagnosticsMenu.py
@@ -193,6 +193,5 @@ class Diagnostics(FloatLayout, MakesmithInitFuncs):
             self.runJustTriangularCuts()
         elif text == "Reset settings to defaults":
             self.resetAllSettings()
-            self.runJustTriangularCuts()
         elif text == "Compute chain calibration factors":
             self.measureChainTolerances()

--- a/main.py
+++ b/main.py
@@ -196,7 +196,7 @@ class GroundControlApp(App):
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
             #updated computed values for z-axis
-            for key in ('KpPosZ', 'KiPosZ', 'KdPosZ', 'propWeightZ'):
+            for key in ('KpPosZ', 'KiPosZ', 'KdPosZ'):
                 if int(self.config.get('Advanced Settings', 'enablePosPIDValues')) == 1:
                     value = float(self.config.get('Advanced Settings', key))
                 else:

--- a/main.py
+++ b/main.py
@@ -197,6 +197,10 @@ class GroundControlApp(App):
                 self.config.set('Computed Settings', key + "Main", value)
             #updated computed values for z-axis
             for key in ('KpPosZ', 'KiPosZ', 'KdPosZ', 'propWeightZ'):
+                if int(self.config.get('Advanced Settings', 'enablePosPIDValues')) == 1:
+                    value = float(self.config.get('Advanced Settings', key))
+                else:
+                    value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key, value)
 
         elif key == 'enableVPIDValues':
@@ -208,6 +212,10 @@ class GroundControlApp(App):
                 self.config.set('Computed Settings', key + "Main", value)
             #updated computed values for z-axis
             for key in ('KpVZ', 'KiVZ', 'KdVZ'):
+                if int(self.config.get('Advanced Settings', 'enablePosPIDValues')) == 1:
+                    value = float(self.config.get('Advanced Settings', key))
+                else:
+                    value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key, value)
         
         elif key == 'chainOverSprocket':

--- a/main.py
+++ b/main.py
@@ -206,6 +206,7 @@ class GroundControlApp(App):
                 else:
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
+            #updated computed values for z-axis
             for key in ('KpVZ', 'KiVZ', 'KdVZ'):
                 self.config.set('Computed Settings', key, value)
         

--- a/main.py
+++ b/main.py
@@ -195,7 +195,9 @@ class GroundControlApp(App):
                 else:
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
-                self.config.set('Computed Settings', key + "Z", value)
+            #updated computed values for z-axis
+            for key in ('KpPosZ', 'KiPosZ', 'KdPosZ', 'propWeight'):
+                self.config.set('Computed Settings', key, value)
 
         elif key == 'enableVPIDValues':
             for key in ('KpV', 'KiV', 'KdV'):
@@ -204,7 +206,8 @@ class GroundControlApp(App):
                 else:
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
-                self.config.set('Computed Settings', key + "Z", value)
+            for key in ('KpVZ', 'KiVZ', 'KdVZ'):
+                self.config.set('Computed Settings', key, value)
         
         elif key == 'chainOverSprocket':
             if value == 'Top':

--- a/main.py
+++ b/main.py
@@ -196,7 +196,7 @@ class GroundControlApp(App):
                     value = maslowSettings.getDefaultValue('Advanced Settings', key)
                 self.config.set('Computed Settings', key + "Main", value)
             #updated computed values for z-axis
-            for key in ('KpPosZ', 'KiPosZ', 'KdPosZ', 'propWeight'):
+            for key in ('KpPosZ', 'KiPosZ', 'KdPosZ', 'propWeightZ'):
                 self.config.set('Computed Settings', key, value)
 
         elif key == 'enableVPIDValues':


### PR DESCRIPTION
This pull request adds advanced settings options for independently setting the PID values for the z-axis. As near as I can tell it is working with the exception that settings are only pushed to the machine when the switch from using the default values to using custom values is switched, however this is the case for all the custom PID value settings not just the z-axis ones and was the case before this pull request so it seems like a separate issue.

The issue is caused by line **191** in `main.py`

`elif key == 'enablePosPIDValues':`

Which only computes the new values when the switch changes position.