### PR TITLE
Fix G38.2 metric default value

### DIFF
--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -142,7 +142,7 @@ class ZAxisPopupContent(GridLayout):
         if self.data.units == "INCHES":
             self.data.gcode_queue.put("G38.2 Z-.2 F2")    #Only go down 0.2 inches...
         else:
-            self.data.gcode_queue.put("G38.2 Z-.5 F50")  #Or 0.5mm.
+            self.data.gcode_queue.put("G38.2 Z-5 F50")  #Or 5mm.
         self.resetMachineUnits()
             
     


### PR DESCRIPTION
G38.2 defaults to 0.2" movement in inches mode, change the metric default to match. It was mistakenly set for 0.5mm, too small to be of value.