### PR TITLE
Background image on working canvas

### DIFF
--- a/DataStructures/data.py
+++ b/DataStructures/data.py
@@ -47,6 +47,12 @@ class Data(EventDispatcher):
     gcodeShift = ObjectProperty([0.0,0.0])                          #the amount that the gcode has been shifted
     logger     =  Logger()                                          #the module which records the machines behavior to review later
     
+    # Background image stuff, persist but not saved
+    backgroundFile = None
+    backgroundTexture = None
+    backgroundManualReg = []
+    backgroundRedraw = BooleanProperty(False)
+    
     '''
     Flags
     '''

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -572,6 +572,23 @@ settings = {
                 "key": "distPerRotRightChainTolerance",
                 "firmwareKey": 41
             }
+        ],
+    "Background Settings":
+        [
+            {
+                "type": "string",
+                "title": "Background File or Directory",
+                "desc": "Current background file",
+                "key": "backgroundFile",
+                "default": ""
+            },
+            {
+                "type": "list",
+                "title": "Manual Registration",
+                "desc": "Relative corner coords for image correction",
+                "key": "manualReg",
+                "default": []
+            },
         ]
 }
 

--- a/UIElements/backgroundMenu.py
+++ b/UIElements/backgroundMenu.py
@@ -21,6 +21,8 @@ class BackgroundMenu(GridLayout, MakesmithInitFuncs):
     def updateAlignmentInConfig(self):
         self.data.config.set('Background Settings', 'manualReg',
                              self.data.backgroundManualReg)
+        self.data.config.set('Background Settings', 'backgroundfile',
+                             str(self.data.backgroundFile))
         self.data.config.write()
 
     def openBackground(self):
@@ -121,9 +123,6 @@ class BackgroundMenu(GridLayout, MakesmithInitFuncs):
             filename = instance.path
         # Save the file in the config...
         self.data.backgroundFile = filename
-        self.data.config.set('Background Settings',
-                             'backgroundfile', str(self.data.backgroundFile))
-        self.data.config.write()
         # close the open file popup
         self.dismiss_popup()
         # new image loaded so clear manual alignment centers

--- a/UIElements/backgroundMenu.py
+++ b/UIElements/backgroundMenu.py
@@ -1,0 +1,141 @@
+import os
+from kivy.uix.gridlayout import GridLayout
+from UIElements.fileBrowser import FileBrowser
+from kivy.uix.popup import Popup
+from DataStructures.makesmithInitFuncs import MakesmithInitFuncs
+from UIElements.backgroundPickDlg import BackgroundPickDlg
+from kivy.core.image import Image as CoreImage
+from PIL import Image as PILImage
+from io import BytesIO
+import json
+
+graphicsExtensions = (".jpg", ".png", ".jp2",".webp",".pbm",".ppm",".pgm")
+
+
+class BackgroundMenu(GridLayout, MakesmithInitFuncs):
+
+    def __init__(self, data, **kwargs):
+        super(BackgroundMenu, self).__init__(**kwargs)
+        self.data = data
+
+    def updateAlignmentInConfig(self):
+        self.data.config.set('Background Settings', 'manualReg',
+                             self.data.backgroundManualReg)
+        self.data.config.write()
+
+    def openBackground(self):
+        '''
+        Open The Pop-up To Load A File
+        Creates a new pop-up which can be used to open a file.
+        '''
+        # Starting path is either where the last opened file was
+        # or the users home directory
+        if not os.path.isdir(self.data.backgroundFile):
+            startingPath = os.path.dirname(self.data.backgroundFile)
+        else:
+            # Don't go up a dir if the "backgroundFile" is a directory!
+            startingPath = self.data.backgroundFile
+        if startingPath is "":
+            startingPath = os.path.expanduser('~')
+        # We want to filter to show only files that ground control can open
+        validFileTypes = graphicsExtensions
+        validFileTypes = ['*{0}'.format(fileType) for fileType in validFileTypes]
+
+        content = FileBrowser(select_string='Select',
+                              favorites=[(startingPath, 'Last Location')], 
+                              path=startingPath, 
+                              filters=validFileTypes, dirselect=False)    
+        content.bind(on_success=self.load, on_canceled=self.dismiss_popup,
+                     on_submit=self.load)         
+        self._popup = Popup(title="Select a file...", content=content,
+                            size_hint=(0.9, 0.9))
+        self._popup.open()
+
+    def reloadBackground(self):
+        self.processBackground()
+        self.close()
+
+    def processBackground(self):
+        if self.data.backgroundFile == "" or os.path.isdir(
+                                                self.data.backgroundFile):
+            self.data.backgroundTexture = None
+            self.data.backgroundManualReg = []
+            self.updateAlignmentInConfig()
+            self.data.backgroundRedraw = True
+            return
+        else:
+            img = PILImage.open(self.data.backgroundFile)
+            img.thumbnail((1920, 1080), PILImage.ANTIALIAS)
+            img = img.transpose(PILImage.FLIP_TOP_BOTTOM)
+            imgBytes = BytesIO()
+            img.save(imgBytes, format="png")
+            imgBytes.seek(0)
+            texture = CoreImage(imgBytes, ext="png").texture
+            self.data.backgroundTexture = texture
+            if self.data.backgroundManualReg:
+                # Already have centers to use; just go on to warp_image
+                self.warp_image()
+            else:
+                # Start the manual alignment process
+                self.realignBackground()
+
+    def realignBackground(self):
+        content = BackgroundPickDlg(self.data)
+        content.setUpData(self.data)
+        content.close = self.close_PickDlg
+        self._popup = Popup(title="Background PointPicker", content=content,
+                            size_hint=(0.9, 0.9))
+        self._popup.open()
+
+    def close_PickDlg(self, instance):
+        if instance.accepted:
+            # Update manual image registration marks
+            self.data.backgroundManualReg = instance.tex_coords
+            # Save the data from the popup
+            self.updateAlignmentInConfig()
+            self.warp_image()
+        self.dismiss_popup()
+        self.close()
+
+    def warp_image(self):
+        self.data.backgroundRedraw = True
+
+    def clear_background(self):
+        '''
+        Clear background
+        '''
+        self.data.backgroundFile = ""
+        self.processBackground()
+        self.close()
+
+    def load(self, instance):
+        '''
+        Load A Background Image File from the file dialog
+        Takes in a file path (from the pop-up filepicker
+        or directory, if no file was picked) and processes it.
+        '''
+        if len(instance.selection) == 1:
+            filename = instance.selection[0]
+        else:
+            # User pressed Submit without picking a file
+            filename = instance.path
+        # Save the file in the config...
+        self.data.backgroundFile = filename
+        self.data.config.set('Background Settings',
+                             'backgroundfile', str(self.data.backgroundFile))
+        self.data.config.write()
+        # close the open file popup
+        self.dismiss_popup()
+        # new image loaded so clear manual alignment centers
+        self.data.backgroundManualReg = []
+        # process it
+        self.processBackground()   
+        # Close the menu, going back to the main page.
+        self.close()
+
+    def dismiss_popup(self, *args):
+        '''
+        Close The File Picker (cancel was pressed instead of OK).
+        '''
+        self._popup.dismiss()
+        pass

--- a/UIElements/backgroundPickDlg.py
+++ b/UIElements/backgroundPickDlg.py
@@ -1,0 +1,88 @@
+from kivy.uix.gridlayout import GridLayout
+from kivy.properties import StringProperty, ListProperty, ObjectProperty
+from DataStructures.makesmithInitFuncs import MakesmithInitFuncs
+from kivy.vector import Vector
+
+
+class BackgroundPickDlg(GridLayout, MakesmithInitFuncs):
+    instructionText = StringProperty("Drag bounding box to frame edges")
+    texture = ObjectProperty(None)
+    tex_coords = ListProperty([0, 0, 1, 0, 1, 1, 0, 1])
+    tex_selection = ListProperty([0, 0, 100, 0, 100, 100, 0, 100])
+
+    def __init__(self, data, **kwargs):
+        super(BackgroundPickDlg, self).__init__(**kwargs)
+        self.data = data
+        # Load the texture
+        self.texture = self.data.backgroundTexture
+        # Window is not set up yet, wait for size.update
+        self.imWidg.bind(size=self.update)
+        self.update()
+
+    def update(self, *args):
+        if self.imWidg.size[0] is not 100 and self.imWidg.size[1] is not 100:
+            # Widget is stable, update the textures bounds
+            self.w, self.h = self.imWidg.size
+            self.coeff_size = [self.w, self.h, self.w, self.h,
+                               self.w, self.h, self.w, self.h]
+            # Place selection box
+            self.tex_selection = [self.w * 0.2, self.h * 0.3,
+                                  self.w * 0.9, self.h * 0.3,
+                                  self.w * 0.9, self.h * 0.9,
+                                  self.w * 0.2, self.h * 0.9]
+            # Why??!!...
+            self.resize_texture()
+            self.reset_image()
+        else:
+            pass  # Wait for widget to resize properly
+
+    def reset_image(self):
+        self.tex_coords = [0, 0, 1, 0, 1, 1, 0, 1]
+
+    def resize_texture(self):
+        coeffs = []
+        padOffx, padOffy = self.imWidg.pos
+        i = 0
+        for (p, s) in zip(self.coeff_size, self.tex_selection):
+            if i % 2:  # y coord
+                if p is not 0:
+                    coeffs.append(float(s - padOffy) / float(p))
+                else:
+                    coeffs.append(0.0 - padOffy)
+            else:  # x coord
+                if p is not 0:
+                    coeffs.append(float(s - padOffx) / float(p))
+                else:
+                    coeffs.append(0.0 - padOffx)
+            i += 1
+        self.tex_coords = coeffs
+
+    def accept_texture(self):
+        self.accepted = True
+        self.close(self)
+
+    def on_touch_down(self, touch):
+        for i in range(4):
+            x, y = self.tex_selection[i*2:i*2+2]
+            if Vector(x - touch.x, y - touch.y).length() < 10:
+                touch.grab(self)
+                touch.ud['tex'] = i
+                return True
+
+        return super(BackgroundPickDlg, self).on_touch_down(touch)
+
+    def on_touch_move(self, touch):
+        if touch.grab_current is not self:
+            return super(BackgroundPickDlg, self).on_touch_move(touch)
+
+        tex = touch.ud.get('tex')
+
+        if tex is not None:
+            self.tex_selection[tex * 2] = touch.x
+            self.tex_selection[tex * 2 + 1] = touch.y
+
+    def on_touch_up(self, touch):
+        if touch.grab_current is self:
+            touch.ungrab(self)
+        else:
+            return super(BackgroundPickDlg, self).on_touch_up(touch)

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -16,6 +16,8 @@ from kivy.graphics.transformation            import Matrix
 from kivy.core.window                        import Window
 from UIElements.modernMenu                   import ModernMenu
 from kivy.metrics                            import dp
+from kivy.graphics.texture                   import Texture
+from kivy.graphics							 import Rectangle
 
 import re
 import math
@@ -53,7 +55,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             Window.bind(on_resize = self.centerCanvas)
 
         self.data.bind(gcode = self.updateGcode)
-        self.data.bind(gcodeShift = self.reloadGcode)
+        self.data.bind(backgroundRedraw = self.updateGcode)
+        self.data.bind(gcodeShift = self.reloadGcode)              #No need to reload if the origin is changed, just clear and redraw
         self.data.bind(gcodeFile = self.centerCanvasAndReloadGcode)
         
         global_variables._keyboard = Window.request_keyboard(self._keyboard_closed, self)
@@ -215,6 +218,12 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
             Line(points = (-width/2,0,width/2,0), dash_offset = 5, group='workspace')
             Line(points = (0, -height/2,0,height/2), dash_offset = 5, group='workspace')
     
+            texture = self.data.backgroundTexture
+            if texture is not None:
+                Rectangle(texture=texture, pos=(-width/2, -height/2), 
+                          size=(width, height),
+                          tex_coords=self.data.backgroundManualReg)
+
     def drawLine(self,gCodeLine,command):
         '''
         
@@ -565,6 +574,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         '''
         
         #reset variables 
+        self.data.backgroundRedraw = False
         self.xPosition = self.data.gcodeShift[0]*self.canvasScaleFactor
         self.yPosition = self.data.gcodeShift[1]*self.canvasScaleFactor
         self.zPosition = 0

--- a/UIElements/screenControls.py
+++ b/UIElements/screenControls.py
@@ -4,6 +4,7 @@ from UIElements.otherFeatures                  import   OtherFeatures
 from DataStructures.makesmithInitFuncs         import   MakesmithInitFuncs
 from UIElements.buttonTemplate                 import   ButtonTemplate
 from kivy.app                                  import   App
+from UIElements.backgroundMenu                 import   BackgroundMenu
 
 
 class ScreenControls(FloatLayout, MakesmithInitFuncs):
@@ -15,10 +16,12 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         Called on creation to set up links to button background textures
         
         '''
-        self.actionsBtn.btnBackground            = self.data.iconPath + 'Generic.png'
-        self.actionsBtn.textColor                = self.data.fontColor
-        self.settingsBtn.btnBackground           = self.data.iconPath + 'Generic.png'
-        self.settingsBtn.textColor               = self.data.fontColor
+        self.actionsBtn.btnBackground = self.data.iconPath + 'Generic.png'
+        self.actionsBtn.textColor = self.data.fontColor
+        self.settingsBtn.btnBackground = self.data.iconPath + 'Generic.png'
+        self.settingsBtn.textColor = self.data.fontColor
+        self.backgroundBtn.btnBackground = self.data.iconPath + 'Generic.png'
+        self.backgroundBtn.textColor = self.data.fontColor
     
     def openSettings(self):
         '''
@@ -53,3 +56,14 @@ class ScreenControls(FloatLayout, MakesmithInitFuncs):
         Close pop-up
         '''
         self._popup.dismiss()
+    
+    def open_background(self):
+        '''
+        Open A Pop-up To Manage the Canvas Background
+        '''
+        content = BackgroundMenu(self.data)
+        content.setUpData(self.data)
+        content.close = self.close_actions
+        self._popup = Popup(title="Background Picture", content=content,
+                            size_hint=(0.5, 0.5))
+        self._popup.open()

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -27,6 +27,7 @@
 <ScreenControls>:
     actionsBtn:actionsBtn
     settingsBtn:settingsBtn
+    backgroundBtn:backgroundBtn
 
     BoxLayout:
         orientation: 'horizontal'
@@ -42,6 +43,10 @@
             text: "Settings"
             funcToCallOnRelease: root.openSettings
             id: settingsBtn
+        ButtonTemplate:
+            text: "Background"
+            funcToCallOnRelease: root.open_background
+            id: backgroundBtn
 
 <GcodeCanvas>:
     scatterObject:scatterObject
@@ -1842,6 +1847,87 @@
             Button:
                 text: "Recompute"
                 on_release: root.recompute()
+
+<BackgroundMenu>:
+    cols:1
+    size: root.size
+    pos: root.pos
+    Button:
+        text: 'Open Background'
+        on_release: root.openBackground()
+	Button:
+		text: 'Re-pick Alignment'
+		on_release: root.realignBackground()
+		disabled: app.data.backgroundTexture is None
+    Button:
+        text: 'Update Background'
+        on_release: root.reloadBackground()
+    Button:
+        text: 'Remove Background'
+        on_release: root.clear_background()
+    Button:
+        text: 'Close'
+        on_press: app.frontpage.gcodecanvas.centerCanvas() #Force canvas redraw
+        on_release: root.close()
+					
+<BackgroundPickDlg>
+    imWidg:imWidg
+    cols: 1
+    size: root.size
+	pos: root.pos
+	GridLayout:
+		cols: 4
+        Button:
+            size_hint_x: None
+			size_hint: 0.5, 1
+            text: 'Reset Image'
+            on_release: root.reset_image()
+        Label:
+            size_hint_x: None
+			size_hint: 2.5, 1
+			text_size: self.width, self.height
+			font_size: sp(self.height)/sp(5)
+            halign: 'center'
+			valign: 'middle'
+            text: root.instructionText
+        Button:
+            size_hint_x: None
+			size_hint: 0.5, 1
+            text: 'Resize Texture'
+            on_release: root.resize_texture()
+        Button:
+            size_hint_x: None
+			size_hint: 0.5, 1
+            text: 'Accept'
+            on_press: app.frontpage.gcodecanvas.centerCanvas() #Force canvas redraw
+            on_release: root.accept_texture()
+    Widget:
+        size_hint_y: None
+        size_hint: 1, 7
+        id: imWidg
+        canvas:
+            Color:
+                rgba: 1, 1, 1, 1
+            Rectangle:
+                texture: root.texture
+                pos: self.pos
+    			size: self.size
+                tex_coords: root.tex_coords
+            Color:
+                rgba: 1, 0, 0, 0.5
+            Line:
+                points: root.tex_selection
+                close: True
+            Color:
+                rgba: 0, 1, 1, 0.3
+            Line:
+                circle: root.tex_selection[0], root.tex_selection[1], 10
+            Line:
+                circle: root.tex_selection[2], root.tex_selection[3], 10
+            Line:
+                circle: root.tex_selection[4], root.tex_selection[5], 10
+            Line:
+                circle: root.tex_selection[6], root.tex_selection[7], 10
 
 <TestPoint>
 

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ import math
 import global_variables
 import sys
 import re
-
+import json
 
 '''
 
@@ -43,6 +43,7 @@ from DataStructures.data          import   Data
 from Connection.nonVisibleWidgets import   NonVisibleWidgets
 from UIElements.notificationPopup import   NotificationPopup
 from Settings                     import   maslowSettings
+from UIElements.backgroundMenu    import   BackgroundMenu
 '''
 
 Main UI Program
@@ -116,6 +117,14 @@ class GroundControlApp(App):
         self.data.gcodeShift = [offsetX,offsetY]
         self.data.config  = self.config
         self.config.add_callback(self.configSettingChange)
+
+        # Background image setup
+        self.data.backgroundFile = self.config.get('Background Settings',
+                                                   'backgroundFile')
+        self.data.backgroundManualReg = json.loads(
+                        self.config.get('Background Settings', 'manualReg'))
+        if self.data.backgroundFile != "":
+            BackgroundMenu(self.data).processBackground()
         
         '''
         Initializations
@@ -149,6 +158,7 @@ class GroundControlApp(App):
         config.setdefaults('Maslow Settings', maslowSettings.getDefaultValueSection('Maslow Settings'))
         config.setdefaults('Advanced Settings', maslowSettings.getDefaultValueSection('Advanced Settings'))
         config.setdefaults('Ground Control Settings', maslowSettings.getDefaultValueSection('Ground Control Settings'))
+        config.setdefaults('Background Settings', maslowSettings.getDefaultValueSection('Background Settings'))
         config.remove_callback(self.computeSettings)
         
     def build_settings(self, settings):


### PR DESCRIPTION
Working Kivy only implementation to load an image onto the maslow bed. #752 

- Background button added up on the top menu bar. 
    - Open Background: Opens an image picker dialog and then loads the Pick Alignment screen
    - Re-pick Alignment: Uses the current file from the prefernces 
    - Update Background: Re-loads the current file and correction points in case of screen artifacts
    - Remove Background: Removes the current file and points from the config file and clears the screen, GCode is unaffected.

Instructions:

1) Take a picture of your sheet material on your Maslow
![nf](https://user-images.githubusercontent.com/187394/44305508-4f5f3080-a336-11e8-9bbf-a99739b85988.jpg)
1) Click the `Background` button then choose `Open Background`
2) Select the image of your sheet material
3) The `Background PointPicker` will popup
![groundcontrol_005](https://user-images.githubusercontent.com/187394/44305522-b7ae1200-a336-11e8-9360-b46dfa89bd31.png)
4) The image ratio does not matter, all skewing is corrected by moving the Cyan circles to the corners of your sheet. The red lines should follow the edges of your sheet material.
![groundcontrol_006](https://user-images.githubusercontent.com/187394/44305532-fa6fea00-a336-11e8-9cb7-c25b2f7eae8c.png)
5) Press `Resize Texture` to get a preview of what you have selected. If you are off on a corner simpily press `Reset Image` and move that point closer. Once you are happy with the result press `Accept`
6) GroundControl will automatically update with the prospective corrected image of your sheet material overlayed on the virtual workspace. 
![groundcontrol_007](https://user-images.githubusercontent.com/187394/44305549-736f4180-a337-11e8-93b1-5febb0c0ebf2.png)
7) You can now very easily tell if your gcode will fit on that sheet material. This way you can utilize as much material as possible.
