### PR TITLE
Fix crash when background image deleted

### DIFF
--- a/UIElements/backgroundMenu.py
+++ b/UIElements/backgroundMenu.py
@@ -58,8 +58,7 @@ class BackgroundMenu(GridLayout, MakesmithInitFuncs):
         self.close()
 
     def processBackground(self):
-        if self.data.backgroundFile == "" or os.path.isdir(
-                                                self.data.backgroundFile):
+        if self.data.backgroundFile == "" or os.path.isdir(self.data.backgroundFile) or not os.path.isfile(self.data.backgroundFile):
             self.data.backgroundTexture = None
             self.data.backgroundManualReg = []
             self.updateAlignmentInConfig()


### PR DESCRIPTION
Ground control would crash on launch if the background image was deleted. Now it will simply not load a background.

![image](https://user-images.githubusercontent.com/9359447/44999166-1fd43900-af70-11e8-9b3d-9e67eb3e683d.png)
