### PR TITLE
Added option to setting plunge depth of Zaxis touch probe.

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -175,6 +175,13 @@ settings = {
         [
             {
                 "type": "string",
+                "title": "Max touch Z-axis plunge",
+                "desc": "Max depth the z axis should plunge in order to find the touch probe",
+                "key": "maxTouchProbePlungeDistance",
+                "default": 0.0,
+	    },
+            {
+                "type": "string",
                 "title": "Encoder Steps per Revolution",
                 "desc": "The number of encoder steps per revolution of the left or right motor",
                 "key": "encoderSteps",

--- a/UIElements/zAxisPopupContent.py
+++ b/UIElements/zAxisPopupContent.py
@@ -139,10 +139,12 @@ class ZAxisPopupContent(GridLayout):
         Probe for Zero Z
         '''
         self.setMachineUnits()
+	plungeDepth = self.data.config.get('Advanced Settings', 'maxTouchProbePlungeDistance')
+
         if self.data.units == "INCHES":
-            self.data.gcode_queue.put("G38.2 Z-.2 F2")    #Only go down 0.2 inches...
+            self.data.gcode_queue.put("G20 G90 G38.2 Z-" + plungeDepth + " F1 G20 G90 M02")   
         else:
-            self.data.gcode_queue.put("G38.2 Z-5 F50")  #Or 5mm.
+            self.data.gcode_queue.put("G21 G90 G38.2 Z-" + plungeDepth + " F1 G21 G90 M02")  
         self.resetMachineUnits()
             
     

--- a/groundcontrol.kv
+++ b/groundcontrol.kv
@@ -643,7 +643,7 @@
                     size_hint_y: 0.2
                     text: "Touch Zero"
                     on_release: root.touchZero()
-                    disabled: True
+                    disabled: False
             Button:
                 text: "Lower"
                 on_release: root.zIn()


### PR DESCRIPTION
1. Enabled touch zero button
1. Made default plunge depth max of 0 to prevent problems if pressed and you don't have touch plate setup.
1. Added advanced option to allow modifying to max plunge depth.  Personally I use it at 20mm to be able to retract change bit, and just press touch.  

I have tested this on my machine.