### PR TITLE
Add Pillow to requirements_osx.txt and requirements_linux.txt

### DIFF
--- a/requirements_linux.txt
+++ b/requirements_linux.txt
@@ -3,6 +3,7 @@ Cython==0.25.2
 Kivy==1.9.1
 Kivy-Garden==0.1.4
 packaging==16.8
+Pillow==5.2.0
 pygame==1.9.3
 pyparsing==2.2.0
 pyserial==3.3

--- a/requirements_osx.txt
+++ b/requirements_osx.txt
@@ -3,6 +3,7 @@ Cython==0.23
 Kivy==1.9.1
 Kivy-Garden==0.1.4
 packaging==16.8
+Pillow==5.2.0
 pygame==1.9.3
 pyparsing==2.2.0
 pyserial==3.3


### PR DESCRIPTION
When I first tried to run GroundControl from source, I got an `ImportError: No module named PIL`.

```
> brew install cython
> virtualenv -p python 2.7 venv
> source venv/bin/activate
> pip install cython # don't understand this, but was necessary
> pip install -r requirements_osx.txt
> python main.py
[INFO              ] [Logger      ] Record log in /Users/johnboiles/.kivy/logs/kivy_18-09-20_5.txt
[INFO              ] [Kivy        ] v1.9.1
[INFO              ] [Python      ] v2.7.10 (default, Oct  6 2017, 22:29:07)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
[INFO              ] [Factory     ] 179 symbols loaded
[INFO              ] [Image       ] Providers: img_tex, img_imageio, img_dds, img_gif, img_pygame (img_pil, img_ffpyplayer ignored)
[INFO              ] [Window      ] Provider: pygame
[INFO              ] [GL          ] OpenGL version <2.1 ATI-1.68.20>
[INFO              ] [GL          ] OpenGL vendor <ATI Technologies Inc.>
[INFO              ] [GL          ] OpenGL renderer <AMD Radeon R9 M370X OpenGL Engine>
[INFO              ] [GL          ] OpenGL parsed version: 2, 1
[INFO              ] [GL          ] Shading version <1.20>
[INFO              ] [GL          ] Texture max size <16384>
[INFO              ] [GL          ] Texture max units <16>
[INFO              ] [Window      ] virtual keyboard not allowed, single mode, not docked
[INFO              ] [Text        ] Provider: pygame
 Traceback (most recent call last):
   File "main.py", line 33, in <module>
     from UIElements.screenControls    import   ScreenControls
   File "/Users/johnboiles/Programming/GroundControl/UIElements/screenControls.py", line 7, in <module>
     from UIElements.backgroundMenu                 import   BackgroundMenu
   File "/Users/johnboiles/Programming/GroundControl/UIElements/backgroundMenu.py", line 8, in <module>
     from PIL import Image as PILImage
 ImportError: No module named PIL
```

Was PIL / Pillow added as dependency recently and possibly this file wasn't updated? Installing Pillow fixes the issue and I'm able to run from source on OSX.