### PR TITLE
Trigger the bound function to the gcode to run on update even if there is no gcode

### DIFF
--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -118,6 +118,7 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         
         filename = self.data.gcodeFile
         if filename is "": #Blank the g-code if we're loading "nothing"
+            self.data.gcode = " "
             self.data.gcode = ""
             return
 


### PR DESCRIPTION
This is needed to fix issue #775 which was causing a bug where the background image didn't behave correctly when there was no gcode file open because the file updateGcode function opts out if there is no file, but we need the refresh process to run