### PR TITLE
Add catch for KeyError exception

### DIFF
--- a/UIElements/modernMenu.py
+++ b/UIElements/modernMenu.py
@@ -146,11 +146,14 @@ class MenuSpawner(Widget):
             return super(MenuSpawner, self).on_touch_down(touch, *args)
 
     def on_touch_move(self, touch, *args):
-        if (
-            touch.ud['menu_timeout'] and
-            dist(touch.pos, touch.opos) > self.cancel_distance
-        ):
-            Clock.unschedule(touch.ud['menu_timeout'])
+        try:
+            if (
+                touch.ud['menu_timeout'] and
+                dist(touch.pos, touch.opos) > self.cancel_distance
+            ):
+                Clock.unschedule(touch.ud['menu_timeout'])
+        except KeyError:
+            pass
         return super(MenuSpawner, self).on_touch_move(touch, *args)
 
     def on_touch_up(self, touch, *args):


### PR DESCRIPTION
This exception when a motion was detected while a popup was open was causing the program to crash. No action is needed for this exception so it is now captured silently.

Fixes #780

Please test and up vote this pull request if the fix seams reasonable and works for you!