### PR TITLE
Change default extend chain length to 1651 mm

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -231,7 +231,7 @@ settings = {
                 "title": "Extend Chain Distance",
                 "desc": "The length in mm that will be extended during chain calibration",
                 "key": "chainExtendLength",
-                "default": 1650,
+                "default": 1651,
                 "firmwareKey": 11
             },
             {


### PR DESCRIPTION
1651 mm is an integral of 6.35 mm (the pitch of a #25 chain) and therefore would result in a tooth being at 12 o'clock after the chains are extended.  Using this value can allow someone to manually reset the chains without having to go through the long, tedious process of having the motor feed out the chain.