### PR TITLE
Clean up serialPortThread() connection handshake

### DIFF
--- a/Connection/serialPortThread.py
+++ b/Connection/serialPortThread.py
@@ -114,12 +114,18 @@ class SerialPortThread(MakesmithInitFuncs):
             msg = ""
             subReadyFlag = True
             
-            self.serialInstance.parity = serial.PARITY_ODD #This is something you have to do to get the connection to open properly. I have no idea why.
-            self.serialInstance.close()
+            
+            if self.serialInstance.isOpen(): 
+                self.serialInstance.close()
+            
             self.serialInstance.open()
-            self.serialInstance.close()
-            self.serialInstance.parity = serial.PARITY_NONE
-            self.serialInstance.open()
+            
+            # reset Arduino boards by toggling DTR signal
+            self.serialInstance.dtr = False
+            self.serialInstance.dtr = True
+            
+            # reset non-Arduino boards by sending 
+            self._write(b'\x18') # ctrl-X
             
             #print "port open?:"
             #print self.serialInstance.isOpen()


### PR DESCRIPTION
• reset Arduino Mega by toggling DTR instead of open/close/open the port
• send ctrl-X to trigger a soft reset for non-Arduino boards

Teensy3.5/3.6 and GrandCentralMetroM4 don't reset when GC does the special Arduino serial-port-reset trick. This adds a one-character command to trigger a soft reset. GRBL and MaslowDue use ctrl-X, so we match that.

There is a matching Firmware PR#513 to handle the ctrl-X.