### PR TITLE
address issue #799

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -314,7 +314,7 @@ settings = {
             {
                 "type": "string",
                 "title": "Chain Sag Correction Value for Triangular Kinematics",
-                "desc": "The scaled value computed by the calibration process to calculate chain sag based on sled weight, chain weight, and workspace angle\\ndefault setting: %s",
+                "desc": "The scaled value computed by the calibration process to calculate chain sag based on sled weight, chain weight, and workspace angle",
                 "key": "chainSagCorrection",
                 "default": 0,
                 "firmwareKey": 37


### PR DESCRIPTION
Unneeded text at the end of the description of this setting in maslowSettings.py writes over the default value in the settings screen. Removing the extra text reveals the default value, which is displayed separately from the title.