### PR TITLE
add Run/Pause/Stop/FAKE_SERVO hotkeys

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -314,7 +314,7 @@ settings = {
             {
                 "type": "string",
                 "title": "Chain Sag Correction Value for Triangular Kinematics",
-                "desc": "The scaled value computed by the calibration process to calculate chain sag based on sled weight, chain weight, and workspace angle\\ndefault setting: %s",
+                "desc": "The scaled value computed by the calibration process to calculate chain sag based on sled weight, chain weight, and workspace angle",
                 "key": "chainSagCorrection",
                 "default": 0,
                 "firmwareKey": 37

--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -484,6 +484,34 @@ settings = {
                 "desc": "Zoom scale for 'Reset View' command.",
                 "key": "viewScale",
                 "default": ".45"
+            },
+            {
+                "type": "string",
+                "title": "Run",
+                "desc": "Pressing this key is the same as clicking the 'Start' button. Note combinations of keys like \'shift\' + \'=\' may not work as expected. Program must be restarted to take effect.",
+                "key": "runKey",
+                "default": "r"
+            },
+            {
+                "type": "string",
+                "title": "Pause",
+                "desc": "Pressing this key is the same as clicking the 'Pause' button. Note combinations of keys like \'shift\' + \'=\' may not work as expected. Program must be restarted to take effect.",
+                "key": "pauseKey",
+                "default": "p"
+            },
+            {
+                "type": "string",
+                "title": "Stop",
+                "desc": "Pressing this key is the same as clicking the 'Stop' button. Note upper case or shifted characters or combinations of keys like \'ctrl\' + \'=\' may not work as expected. Program must be restarted to take effect.",
+                "key": "stopKey",
+                "default": "s"
+            },
+            {
+                "type": "string",
+                "title": "FAKE_SERVO Off",
+                "desc": "Pressing this key will turn FAKE_SERVO off. Press this key along with 'cmd', 'alt' , or 'cmd' to turn FAKE_SERVO on. Program must be restarted to take effect.",
+                "key": "fakeServo_Off",
+                "default": "f"
             }
         ],
     "Computed Settings": #These are setting calculated from the user inputs on other settings, they are not directly seen by the user

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -91,6 +91,8 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         scaleFactor = .03
         anchor = (0,0)
         
+#         print 'gcodeCanvas',keycode, text, modifiers  # handy for exploring keyboard input
+        
         if keycode[1] == self.data.config.get('Ground Control Settings', 'zoomIn'):
             mat = Matrix().scale(1-scaleFactor, 1-scaleFactor, 1)
             self.scatterInstance.apply_transform(mat, anchor)
@@ -98,6 +100,21 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         elif keycode[1] == self.data.config.get('Ground Control Settings', 'zoomOut'):
             mat = Matrix().scale(1+scaleFactor, 1+scaleFactor, 1)
             self.scatterInstance.apply_transform(mat, anchor)
+            return True # we handled this key - don't pass to other callbacks
+        elif keycode[1] == self.data.config.get('Ground Control Settings', 'runKey'):
+            self.parent.startRun() # "click" the 'Run' button
+            return True # we handled this key - don't pass to other callbacks
+        elif keycode[1] == self.data.config.get('Ground Control Settings', 'pauseKey'):
+            self.parent.pause() # "click" the 'Pause' button
+            return True # we handled this key - don't pass to other callbacks
+        elif keycode[1] == self.data.config.get('Ground Control Settings', 'stopKey'):
+            self.parent.stopRun() # "click" the 'Stop' button
+            return True # we handled this key - don't pass to other callbacks
+        elif keycode[1] == self.data.config.get('Ground Control Settings', 'fakeServo_Off'):
+            if 'ctrl' in modifiers or 'alt' in modifiers or 'meta' in modifiers:
+                self.data.gcode_queue.put("B99 ON \n")
+            else:
+                self.data.gcode_queue.put("B99 OFF \n")
             return True # we handled this key - don't pass to other callbacks
         else:
             return False # we didn't handle this key - let next callback handle it


### PR DESCRIPTION
 - The Run/Pause/Stop hotkeys call the same routine that clicking the corresponding button calls. That handles updating the text on the ‘Pause’ button when it changes state.
 - The key assignments are editable in Settings/GroundControlSettings, though that limits us to one key per action. Defaulted to 'r', 'p', 's' (lower case)
 - The escape key can be assigned using the word escape, the spacebar using the word spacebar. Avoid upper case, shifted or meta characters.
 - Assign a character to disable FAKE_SERVO mode, press that key along with 'ctrl' or 'alt' or 'cmd' to enable FAKE_SERVO. Defaulted to 'f' for off.