### PR TITLE
add switch to disable FAKE_SERVO mode

### DIFF
--- a/Settings/maslowSettings.py
+++ b/Settings/maslowSettings.py
@@ -507,6 +507,14 @@ settings = {
                 "default": "s"
             },
             {
+                "type": "options",
+                "title": "FAKE_SERVO allowed",
+                "desc": "Should GroundControl allow FAKE_SERVO mode?",
+                "key": "fsModeAllowed",
+                "options": ["Not allowed", "Allowed"],
+                "default": "Not allowed",
+            },
+            {
                 "type": "string",
                 "title": "FAKE_SERVO Off",
                 "desc": "Pressing this key will turn FAKE_SERVO off. Press this key along with 'cmd', 'alt' , or 'cmd' to turn FAKE_SERVO on. Program must be restarted to take effect.",

--- a/UIElements/gcodeCanvas.py
+++ b/UIElements/gcodeCanvas.py
@@ -110,14 +110,24 @@ class GcodeCanvas(FloatLayout, MakesmithInitFuncs):
         elif keycode[1] == self.data.config.get('Ground Control Settings', 'stopKey'):
             self.parent.stopRun() # "click" the 'Stop' button
             return True # we handled this key - don't pass to other callbacks
+#         elif keycode[1] == self.data.config.get('Ground Control Settings', 'fakeServo_Off'):
+#             if self.data.config.get('Ground Control Settings', 'fsModeAllowed') == "Allowed":
+#                 if 'ctrl' in modifiers or 'alt' in modifiers or 'meta' in modifiers:
+#                     self.data.gcode_queue.put("B99 ON \n")
+#                 else:
+#                     self.data.gcode_queue.put("B99 OFF \n")
+#                 return True # we handled this key - don't pass to other callbacks
+#             else:
+#                 return False # we didn't handle this key - let next callback handle it
         elif keycode[1] == self.data.config.get('Ground Control Settings', 'fakeServo_Off'):
             if 'ctrl' in modifiers or 'alt' in modifiers or 'meta' in modifiers:
-                self.data.gcode_queue.put("B99 ON \n")
+                if self.data.config.get('Ground Control Settings', 'fsModeAllowed') == "Allowed":
+                    self.data.gcode_queue.put("B99 ON \n")
             else:
                 self.data.gcode_queue.put("B99 OFF \n")
             return True # we handled this key - don't pass to other callbacks
         else:
-            return False # we didn't handle this key - let next callback handle it
+                return False # we didn't handle this key - let next callback handle it
 
     def isClose(self, a, b):
         return abs(a-b) <= self.data.tolerance


### PR DESCRIPTION
 - add a new switch that defaults to "Not allowed"
 - FAKE_SERVO hot key only works if switch set to "Allowed"
 - FAKE_SERVO can be turned off with hot key regardless of switch position


This PR addresses Firmware issue #531 "Does FAKE_SERVO need an alert when activating."