### PR TITLE
Change scale factor for safe z-height

### DIFF
--- a/UIElements/runMenu.py
+++ b/UIElements/runMenu.py
@@ -17,7 +17,7 @@ class RunMenu(FloatLayout):
         self.data.gcode_queue.put("G90  ")
         
         safeHeightMM = float(self.data.config.get('Maslow Settings', 'zAxisSafeHeight'))
-        safeHeightInches = safeHeightMM / 25.5
+        safeHeightInches = safeHeightMM / 25.4
         if self.data.units == "INCHES":
             self.data.gcode_queue.put("G00 Z" + '%.3f'%(safeHeightInches))
         else:


### PR DESCRIPTION
Fix the scale factor for the safe z-height inches to mm conversion from 25.5 mm to 25.4mm per inch.

Fixes #809 